### PR TITLE
[FEAT] 매니저 리그 페이지 API 연결

### DIFF
--- a/apps/manager/app/_components/MatchOverview/index.tsx
+++ b/apps/manager/app/_components/MatchOverview/index.tsx
@@ -15,7 +15,7 @@ type MatchOverviewProps = {
 };
 
 const MatchOverview = ({ state }: MatchOverviewProps) => {
-  const { data } = useGamesByLeagueList('2024', state);
+  const { data } = useGamesByLeagueList({ state });
 
   return (
     <>

--- a/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
@@ -1,6 +1,8 @@
 'use client';
 import { useLeague } from '@hcc/api';
 import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
 
 import Card from '@/components/Card';
 import { formatTime } from '@/utils/time';
@@ -12,7 +14,13 @@ type LeagueOverviewProps = {
 };
 
 const LeagueOverview = ({ leagueId }: LeagueOverviewProps) => {
-  const { data: league } = useLeague(leagueId);
+  const { data: league, isLoading, error } = useLeague(leagueId);
+
+  const router = useRouter();
+
+  useEffect(() => {
+    if (!isLoading && error) router.replace('/');
+  }, [isLoading, error, router]);
 
   if (!league) return null;
 

--- a/apps/manager/app/league/_components/LeagueCard/index.tsx
+++ b/apps/manager/app/league/_components/LeagueCard/index.tsx
@@ -10,7 +10,7 @@ import { formatTime } from '@/utils/time';
 import * as styles from './LeagueCard.css';
 
 const LeagueCard = () => {
-  const { data: leagues } = useLeaguesDetail('2024');
+  const { data: leagues } = useLeaguesDetail();
 
   return (
     <>

--- a/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
+++ b/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
@@ -124,7 +124,7 @@ export const LeagueForm = ({
               <Select onValueChange={field.onChange} defaultValue={field.value}>
                 <FormLabel>진행 방식</FormLabel>
                 <FormControl>
-                  <SelectTrigger>
+                  <SelectTrigger type="button">
                     <SelectValue>{field.value}강</SelectValue>
                   </SelectTrigger>
                 </FormControl>

--- a/apps/manager/app/league/_components/LeagueForm/types.ts
+++ b/apps/manager/app/league/_components/LeagueForm/types.ts
@@ -3,7 +3,7 @@ import { z } from 'zod';
 export const leagueFormSchema = z.object({
   leagueName: z.string().min(1, { message: '대회명을 입력해주세요' }),
   startDate: z.date({ message: '시작일을 입력해주세요' }),
-  endDate: z.date().nullable(),
+  endDate: z.date({ message: '종료일을 입력해주세요' }),
   round: z
     .string()
     .min(1, { message: '라운드를 입력해주세요' })
@@ -14,6 +14,5 @@ export type LeagueFormSchema = z.infer<typeof leagueFormSchema>;
 
 export const leagueDefaultValues = {
   leagueName: '',
-  endDate: null,
   round: '-',
 };

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -1,10 +1,13 @@
 'use client';
+import { useCreateLeague } from '@hcc/api';
 import { toast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
 import { useForm } from 'react-hook-form';
 
 import Layout from '@/components/Layout';
 import Tip from '@/components/Tip';
+import { formatTime } from '@/utils/time';
 
 import {
   leagueDefaultValues,
@@ -14,17 +17,37 @@ import {
 } from '../_components/LeagueForm';
 
 export default function Page() {
+  const router = useRouter();
+
   const methods = useForm<LeagueFormSchema>({
     resolver: zodResolver(leagueFormSchema),
     defaultValues: leagueDefaultValues,
   });
 
+  const { mutate: createLeagueMutation } = useCreateLeague();
+
   const onSubmit = (data: LeagueFormSchema) => {
-    toast({
-      title: '테스트용 대회 생성 메시지',
-      description: JSON.stringify(data),
-    });
-    // TODO: API 호출 구현 필요
+    const { leagueName, round, startDate, endDate } = data;
+    createLeagueMutation(
+      {
+        name: leagueName,
+        maxRound: Number(round),
+        startAt: formatTime(startDate, 'YYYY-MM-DDTHH:mm:ss'),
+        endAt: formatTime(endDate, 'YYYY-MM-DDTHH:mm:ss'),
+      },
+      {
+        onSuccess: () => {
+          toast({ title: '대회가 생성되었습니다', variant: 'destructive' });
+          router.back();
+        },
+        onError: () => {
+          toast({
+            title: '대회 생성에 실패했습니다',
+            variant: 'destructive',
+          });
+        },
+      },
+    );
   };
 
   return (

--- a/packages/api/src/fetcher.ts
+++ b/packages/api/src/fetcher.ts
@@ -31,4 +31,6 @@ export const fetcher = {
     request<T>(instance.put<T>(pathname, data, config)),
   delete: <T>(pathname: string, config?: AxiosRequestConfig) =>
     request<T>(instance.delete<T>(pathname, config)),
+  patch: <T>(pathname: string, data?: unknown, config?: AxiosRequestConfig) =>
+    request<T>(instance.patch<T>(pathname, data, config)),
 };

--- a/packages/api/src/mutations/index.tsx
+++ b/packages/api/src/mutations/index.tsx
@@ -1,15 +1,21 @@
+import useCreateLeague from './useCreateLeague';
 import useCreateLeagueTeam from './useCreateLeagueTeam';
+import useDeleteLeague from './useDeleteLeague';
 import useDeleteLeagueTeam from './useDeleteLeagueTeam';
 import useGeneratePresignedUrl from './useGeneratePresignedUrl';
 import useLoginMutation from './useManagerLogin';
+import useUpdateLeague from './useUpdateLeague';
 import useUpdateLeagueTeam from './useUpdateLeagueTeam';
 import useUploadImage from './useUploadImage';
 
 export {
+  useCreateLeague,
   useCreateLeagueTeam,
+  useDeleteLeague,
   useDeleteLeagueTeam,
   useGeneratePresignedUrl,
   useLoginMutation,
+  useUpdateLeague,
   useUpdateLeagueTeam,
   useUploadImage,
 };

--- a/packages/api/src/mutations/useCreateLeague.ts
+++ b/packages/api/src/mutations/useCreateLeague.ts
@@ -1,0 +1,24 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import { queryKeys } from '../queryKey';
+import { LeagueCreateType } from '../types';
+
+type Request = LeagueCreateType;
+
+const postCreateLeague = (request: Request) => {
+  return fetcher.post<void>(`/leagues`, { ...request });
+};
+
+const useCreateLeague = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postCreateLeague,
+    onSuccess: async () => {
+      await queryClient.invalidateQueries(queryKeys.leagues());
+    },
+  });
+};
+
+export default useCreateLeague;

--- a/packages/api/src/mutations/useDeleteLeague.ts
+++ b/packages/api/src/mutations/useDeleteLeague.ts
@@ -1,0 +1,26 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import { queryKeys } from '../queryKey';
+
+type Request = {
+  leagueId: string;
+};
+
+const deleteLeague = ({ leagueId }: Request) => {
+  return fetcher.delete<void>(`/leagues/${leagueId}`);
+};
+
+const useDeleteLeague = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: deleteLeague,
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries(queryKeys.leagues());
+      await queryClient.invalidateQueries(queryKeys.league(variables.leagueId));
+    },
+  });
+};
+
+export default useDeleteLeague;

--- a/packages/api/src/mutations/useDeleteLeagueTeam.ts
+++ b/packages/api/src/mutations/useDeleteLeagueTeam.ts
@@ -17,12 +17,12 @@ const useDeleteLeagueTeam = () => {
   return useMutation({
     mutationFn: deleteLeagueTeam,
     onSuccess: async (_, variables) => {
-      await queryClient.invalidateQueries({
-        queryKey: [
-          queryKeys.leagueTeam(variables.teamId).queryKey,
-          queryKeys.leagueTeams(variables.leagueId).queryKey,
-        ],
-      });
+      await queryClient.invalidateQueries(
+        queryKeys.leagueTeam(variables.teamId),
+      );
+      await queryClient.invalidateQueries(
+        queryKeys.leagueTeams(variables.leagueId),
+      );
     },
   });
 };

--- a/packages/api/src/mutations/useUpdateLeague.ts
+++ b/packages/api/src/mutations/useUpdateLeague.ts
@@ -1,0 +1,28 @@
+import { useMutation, useQueryClient } from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import { queryKeys } from '../queryKey';
+import { LeagueUpdateType } from '../types';
+
+type Request = LeagueUpdateType & {
+  leagueId: string;
+};
+
+const putUpdateLeague = (request: Request) => {
+  const { leagueId, ...rest } = request;
+  return fetcher.put<void>(`/leagues/${leagueId}`, { ...rest });
+};
+
+const useUpdateLeague = () => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: putUpdateLeague,
+    onSuccess: async (_, variables) => {
+      await queryClient.invalidateQueries(queryKeys.leagues());
+      await queryClient.invalidateQueries(queryKeys.league(variables.leagueId));
+    },
+  });
+};
+
+export default useUpdateLeague;

--- a/packages/api/src/mutations/useUpdateLeagueTeam.ts
+++ b/packages/api/src/mutations/useUpdateLeagueTeam.ts
@@ -11,7 +11,7 @@ type Request = TeamUpdateType & {
 
 const putUpdateLeagueTeam = (request: Request) => {
   const { leagueId, teamId, ...rest } = request;
-  return fetcher.put<void>(`/leagues/${leagueId}/teams/${teamId}`, {
+  return fetcher.patch<void>(`/leagues/${leagueId}/teams/${teamId}`, {
     ...rest,
   });
 };

--- a/packages/api/src/mutations/useUpdateLeagueTeam.ts
+++ b/packages/api/src/mutations/useUpdateLeagueTeam.ts
@@ -22,12 +22,12 @@ const useUpdateLeagueTeam = () => {
   return useMutation({
     mutationFn: putUpdateLeagueTeam,
     onSuccess: async (_, variables) => {
-      await queryClient.invalidateQueries({
-        queryKey: [
-          queryKeys.leagueTeam(variables.teamId).queryKey,
-          queryKeys.leagueTeams(variables.leagueId).queryKey,
-        ],
-      });
+      await queryClient.invalidateQueries(
+        queryKeys.leagueTeam(variables.teamId),
+      );
+      await queryClient.invalidateQueries(
+        queryKeys.leagueTeams(variables.leagueId),
+      );
     },
   });
 };

--- a/packages/api/src/queries/useGamesByLeagueList.ts
+++ b/packages/api/src/queries/useGamesByLeagueList.ts
@@ -5,12 +5,12 @@ import { StateType } from '../types';
 
 import { useLeagues } from './index';
 
-type GamesByLeagueListPayload = {
+type Params = {
   year?: string;
   state: StateType;
 };
 
-const useGamesByLeagueList = ({ year, state }: GamesByLeagueListPayload) => {
+const useGamesByLeagueList = ({ year, state }: Params) => {
   const { data: leagues } = useLeagues(year);
   const leagueList = leagues ?? [];
 

--- a/packages/api/src/queries/useGamesByLeagueList.ts
+++ b/packages/api/src/queries/useGamesByLeagueList.ts
@@ -5,7 +5,12 @@ import { StateType } from '../types';
 
 import { useLeagues } from './index';
 
-const useGamesByLeagueList = (year: string, state: StateType) => {
+type GamesByLeagueListPayload = {
+  year?: string;
+  state: StateType;
+};
+
+const useGamesByLeagueList = ({ year, state }: GamesByLeagueListPayload) => {
   const { data: leagues } = useLeagues(year);
   const leagueList = leagues ?? [];
 

--- a/packages/api/src/types/league.ts
+++ b/packages/api/src/types/league.ts
@@ -1,7 +1,7 @@
 export type LeagueType = {
   name: string;
-  startAt: Date;
-  endAt: Date;
+  startAt: string;
+  endAt: string;
   maxRound: number;
   inProgressRound: number;
   isInProgress: boolean;
@@ -14,4 +14,16 @@ export type LeagueListType = Omit<LeagueType, 'startAt' | 'endAt'> & {
 export type LeagueDetailType = {
   leagueId: number;
   league: LeagueType;
+};
+
+export type LeagueCreateType = Omit<
+  LeagueType,
+  'inProgressRound' | 'isInProgress'
+>;
+
+export type LeagueUpdateType = Omit<
+  LeagueType,
+  'inProgressRound' | 'isInProgress' | 'maxRound'
+> & {
+  maxRound: string;
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #308 

## ✅ 작업 내용

- 구현된 리그 페이지에 API를 연결했습니다. 

## ♾️ 기타

- 리그 팀 수정 부분에서 401 오류가 발생하고 있어 해결이 필요합니다.
