### PR TITLE
[FEAT] 리그 경기 생성 페이지 추가

### DIFF
--- a/apps/manager/app/_components/MatchOverview/index.tsx
+++ b/apps/manager/app/_components/MatchOverview/index.tsx
@@ -23,7 +23,7 @@ const MatchOverview = ({ state }: MatchOverviewProps) => {
         <Fragment key={league.leagueId}>
           <div className={styles.leagueContainer}>
             <span className={styles.leagueContent}>
-              <Tag colorScheme={state === 'playing' ? 'primary' : 'secondary'}>
+              <Tag colorScheme={state === 'PLAYING' ? 'primary' : 'secondary'}>
                 {stateMap[state]}
               </Tag>
               <h3 className={styles.leagueName}>{league.name}</h3>

--- a/apps/manager/app/league/[leagueId]/_components/GameCard/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameCard/index.tsx
@@ -32,7 +32,7 @@ const GameCard = ({ leagueId, state }: GameCardProps) => {
             <Card.Root>
               <Card.Head>
                 <Tag
-                  colorScheme={state === 'playing' ? 'primary' : 'secondary'}
+                  colorScheme={state === 'PLAYING' ? 'primary' : 'secondary'}
                 >
                   {stateMap[state]}
                 </Tag>

--- a/apps/manager/app/league/[leagueId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/page.tsx
@@ -24,13 +24,13 @@ export default function Page({ params }: PageProps) {
 
       <Divider height={11} />
 
-      <GameCard leagueId={leagueId} state="playing" />
+      <GameCard leagueId={leagueId} state="PLAYING" />
 
       <Divider height={2} />
-      <GameCard leagueId={leagueId} state="scheduled" />
+      <GameCard leagueId={leagueId} state="SCHEDULED" />
 
       <Divider height={2} />
-      <GameCard leagueId={leagueId} state="finished" />
+      <GameCard leagueId={leagueId} state="FINISHED" />
     </Layout>
   );
 }

--- a/apps/manager/app/league/[leagueId]/register-game/_components/lineup-badge/index.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/lineup-badge/index.tsx
@@ -1,0 +1,41 @@
+import { AddIcon, CheckIcon } from '@hcc/icons';
+import { Badge, Icon } from '@hcc/ui';
+import { clsx } from 'clsx';
+import { ElementRef, forwardRef } from 'react';
+
+import * as styles from './styles.css';
+
+type LineupBadgeProps = {
+  checked?: boolean;
+};
+
+const LineupBadge = forwardRef<ElementRef<typeof Badge>, LineupBadgeProps>(
+  ({ checked = false }, ref) => {
+    if (checked)
+      return (
+        <Badge
+          className={styles.badge}
+          colorScheme="accentPrimary"
+          ref={ref}
+          onClick={e => e.stopPropagation()}
+        >
+          <Icon source={CheckIcon} color="white" width="16" height="16" />
+          라인업
+        </Badge>
+      );
+
+    return (
+      <Badge
+        className={clsx(styles.badge, styles.modifyBadge)}
+        ref={ref}
+        onClick={e => e.stopPropagation()}
+      >
+        <Icon source={AddIcon} color="white" width="16" height="16" />
+        라인업 수정
+      </Badge>
+    );
+  },
+);
+LineupBadge.displayName = 'LineupBadge';
+
+export default LineupBadge;

--- a/apps/manager/app/league/[leagueId]/register-game/_components/lineup-badge/styles.css.ts
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/lineup-badge/styles.css.ts
@@ -1,0 +1,12 @@
+import { rem } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+
+export const badge = style({
+  backgroundColor: '#C1C5CA',
+  paddingBlock: `${rem(7)} !important`,
+  paddingInline: `${rem(6)} !important`,
+});
+
+export const modifyBadge = style({
+  backgroundColor: '#C1C5CA !important',
+});

--- a/apps/manager/app/league/[leagueId]/register-game/_components/lineup-sheet/index.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/lineup-sheet/index.tsx
@@ -1,0 +1,104 @@
+// ! LineupSheet를 사용할 때 주석 제거해서 에러 없애기
+
+// import { useLeagueTeamDetail } from '@hcc/api';
+// import { CheckIcon } from '@hcc/icons';
+// import {
+//   BottomSheet,
+//   BottomSheetContent,
+//   BottomSheetDescription,
+//   BottomSheetHeader,
+//   BottomSheetTitle,
+//   BottomSheetTrigger,
+//   Button,
+//   Icon,
+//   ScrollArea,
+// } from '@hcc/ui';
+// import { ReactNode, useState } from 'react';
+// import { UseFormReturn } from 'react-hook-form';
+
+// import Divider from '@/components/Divider';
+
+// import * as styles from './styles.css';
+// import { RegisterGameFormSchema } from '../../page';
+
+// type LineupSheetProps = {
+//   methods: UseFormReturn<RegisterGameFormSchema>;
+//   teamId: string;
+//   children: ReactNode;
+// };
+
+// export default function LineupSheet({
+//   methods,
+//   teamId,
+//   children,
+// }: LineupSheetProps) {
+//   const [open, setOpen] = useState(false);
+//   const { data: teamDetail } = useLeagueTeamDetail(teamId);
+
+//   const addPlayer = (playerId: string) => {
+//     methods.setValue('playersOfTeam1', [
+//       ...methods.getValues('playersOfTeam1'),
+//       playerId,
+//     ]);
+//   };
+
+//   return (
+//     <BottomSheet open={open}>
+//       <BottomSheetTrigger
+//         asChild
+//         onClick={e => {
+//           e.stopPropagation();
+//           setOpen(prev => !prev);
+//         }}
+//       >
+//         {children}
+//       </BottomSheetTrigger>
+//       <BottomSheetContent className={styles.content}>
+//         <BottomSheetHeader
+//           className={styles.header}
+//           style={{ display: 'flex' }}
+//         >
+//           <div className={styles.headerInfo}>
+//             <BottomSheetTitle className={styles.title}>
+//               라인업 수정
+//             </BottomSheetTitle>
+//             <BottomSheetDescription className={styles.description}>
+//               {teamDetail.teamName}
+//             </BottomSheetDescription>
+//           </div>
+//           <button className={styles.editButton}>편집</button>
+//         </BottomSheetHeader>
+
+//         <ScrollArea className={styles.scrollArea}>
+//           <div className={styles.block}>
+//             <h3 className={styles.division}>선발</h3>
+//             <ul className={styles.playerList}>
+//               {teamDetail.leagueTeamPlayers.map(player => (
+//                 <li key={player.id}>
+//                   <div className={styles.card}>{player.name}</div>
+//                   <div className={styles.backNumber}>{player.number}</div>
+
+//                   <Button asChild onClick={() => addPlayer(`${player.id}`)}>
+//                     <Icon
+//                       role="button"
+//                       source={CheckIcon}
+//                       width={24}
+//                       height={24}
+//                     />
+//                   </Button>
+//                 </li>
+//               ))}
+//             </ul>
+//           </div>
+
+//           <Divider height={6} />
+
+//           <div className={styles.block}>
+//             <h3 className={styles.division}>후보</h3>
+//             <ul className={styles.playerList}></ul>
+//           </div>
+//         </ScrollArea>
+//       </BottomSheetContent>
+//     </BottomSheet>
+//   );
+// }

--- a/apps/manager/app/league/[leagueId]/register-game/_components/lineup-sheet/styles.css.ts
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/lineup-sheet/styles.css.ts
@@ -1,0 +1,130 @@
+import { rem, theme } from '@hcc/styles';
+import { breakpoint } from '@hcc/styles/dist/responsive.css';
+import { style } from '@vanilla-extract/css';
+
+export const scrollArea = style({
+  height: '9999px',
+});
+
+export const content = style({
+  width: '100%',
+  height: 'calc(100dvh - 15%)',
+  margin: '0 auto',
+
+  ...breakpoint('tablet', {
+    width: theme.sizes.appWidth,
+  }),
+});
+
+export const innerContent = style({
+  width: `min(${theme.sizes.appWidth}, 100%)`,
+  height: '100%',
+  margin: '0 auto',
+});
+
+export const header = style({
+  display: 'flex',
+  justifyContent: 'space-between',
+  alignItems: 'start',
+  flexDirection: 'row',
+
+  width: '100%',
+  paddingTop: rem(32),
+});
+
+export const headerInfo = style({
+  display: 'flex',
+  flexDirection: 'column',
+  alignItems: 'start',
+});
+
+export const title = style({
+  fontSize: rem(24),
+  fontWeight: 600,
+  color: theme.colors.black900,
+
+  marginBottom: rem(8),
+});
+
+export const description = style({
+  fontSize: rem(16),
+  color: theme.colors.black400,
+});
+
+export const editButton = style({
+  color: theme.colors.black300,
+  fontSize: rem(18),
+
+  ':hover': {
+    color: theme.colors.black500,
+  },
+
+  ':focus-visible': {
+    color: theme.colors.black500,
+  },
+});
+
+export const block = style({
+  width: theme.sizes.appWidth,
+  paddingInline: theme.sizes.appInlinePadding,
+});
+
+export const division = style({
+  marginTop: rem(24),
+  marginBottom: rem(16),
+
+  fontSize: rem(16),
+  fontWeight: 500,
+  color: theme.colors.black900,
+});
+
+export const playerList = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(16),
+
+  width: '100%',
+  marginBottom: rem(24),
+});
+
+export const playerItem = style({
+  display: 'grid',
+  alignItems: 'center',
+  gridTemplateColumns: `1fr ${rem(72)} auto`,
+  gap: rem(8),
+
+  width: '100%',
+  height: rem(60),
+});
+
+export const card = style({
+  display: 'flex',
+  alignItems: 'center',
+  gap: rem(10),
+
+  height: '100%',
+  color: theme.colors.black900,
+  paddingInline: rem(18),
+  borderRadius: rem(8),
+  border: `1px solid ${theme.colors.black25}`,
+  backgroundColor: theme.colors.white,
+});
+
+export const backNumber = style({
+  display: 'flex',
+  justifyContent: 'center',
+  alignItems: 'center',
+
+  height: '100%',
+  color: theme.colors.black900,
+  paddingInline: rem(18),
+  borderRadius: rem(8),
+  border: `1px solid ${theme.colors.black25}`,
+  backgroundColor: theme.colors.white,
+});
+
+export const divider = style({
+  backgroundColor: theme.colors.black25,
+  width: '100%',
+  padding: 0,
+});

--- a/apps/manager/app/league/[leagueId]/register-game/_components/time-input/index.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/time-input/index.tsx
@@ -1,0 +1,39 @@
+import { TimerOutlineIcon } from '@hcc/icons';
+import { Icon } from '@hcc/ui';
+import { clsx } from 'clsx';
+import { ComponentProps, forwardRef, useImperativeHandle, useRef } from 'react';
+
+import * as styles from './styles.css';
+
+type TimeInputProps = ComponentProps<'input'>;
+
+const TimeInput = forwardRef<HTMLInputElement, TimeInputProps>(
+  ({ className, ...props }, ref) => {
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    useImperativeHandle(ref, () => inputRef.current as HTMLInputElement);
+
+    const handleClickInput = () => {
+      inputRef.current?.showPicker();
+    };
+
+    return (
+      <button
+        type="button"
+        className={styles.wrapper}
+        onClick={handleClickInput}
+      >
+        <input
+          ref={inputRef}
+          type="time"
+          className={clsx(styles.timeInput, className)}
+          {...props}
+        />
+        <Icon source={TimerOutlineIcon} className={styles.icon} />
+      </button>
+    );
+  },
+);
+TimeInput.displayName = 'TimeInput';
+
+export default TimeInput;

--- a/apps/manager/app/league/[leagueId]/register-game/_components/time-input/styles.css.ts
+++ b/apps/manager/app/league/[leagueId]/register-game/_components/time-input/styles.css.ts
@@ -1,0 +1,65 @@
+import { rem, theme } from '@hcc/styles';
+import { globalStyle, style } from '@vanilla-extract/css';
+
+export const icon = style({
+  position: 'absolute',
+  right: rem(18),
+  top: '50%',
+  transform: 'translate(0, -50%)',
+  cursor: 'inherit',
+
+  color: theme.colors.black100,
+  strokeWidth: 1,
+});
+
+export const wrapper = style({
+  position: 'relative',
+  display: 'flex',
+  justifyContent: 'space-between',
+  width: '100%',
+
+  selectors: {
+    '&:focus-within::after': {
+      content: '',
+      position: 'absolute',
+      top: -1,
+      right: -1,
+      bottom: -1,
+      left: -1,
+      height: 'inherit',
+      border: `2px solid ${theme.colors.accent.primary}`,
+      transition: 'all .2s cubic-bezier(.4,0,.2,1)',
+      zIndex: 2,
+      borderRadius: rem(8),
+    },
+  },
+});
+
+globalStyle(`label:has(+ ${wrapper})`, {
+  transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
+});
+
+export const timeInput = style({
+  width: '100%',
+  height: rem(60),
+
+  border: '1px solid #F3F3F5',
+  borderRadius: rem(8),
+
+  backgroundColor: '#fff',
+
+  paddingInline: rem(18),
+  cursor: 'pointer',
+
+  selectors: {
+    '&::placeholder': {
+      color: '#79828C',
+    },
+
+    // '&:focus-within:'
+  },
+});
+
+globalStyle(`${timeInput}[type="time"]::-webkit-calendar-picker-indicator`, {
+  display: 'none',
+});

--- a/apps/manager/app/league/[leagueId]/register-game/_constants/index.ts
+++ b/apps/manager/app/league/[leagueId]/register-game/_constants/index.ts
@@ -1,0 +1,26 @@
+import { StateType } from '@hcc/api';
+
+export const QUARTERS_DB = {
+  전반전: '전반전',
+  후반전: '후반전',
+  '경기 전': '경기전',
+  승부차기: '승부차기',
+  '경기 후': '경기후',
+} as const;
+
+export const QUARTER_ID: Record<QUARTER_KEY, number> = {
+  전반전: 4,
+  후반전: 5,
+  경기전: 6,
+  승부차기: 7,
+  경기후: 8,
+} as const;
+
+export type QUARTER_KEY = (typeof QUARTERS_DB)[keyof typeof QUARTERS_DB];
+
+export const getStateByQuarter = (quarter: QUARTER_KEY): StateType => {
+  if (quarter === '경기전') return 'SCHEDULED';
+  if (quarter === '경기후') return 'FINISHED';
+
+  return 'PLAYING';
+};

--- a/apps/manager/app/league/[leagueId]/register-game/page.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/page.tsx
@@ -1,0 +1,394 @@
+/* eslint-disable react-hooks/exhaustive-deps */
+'use client';
+
+import {
+  LegacyRoundType,
+  StateType,
+  useCreateGame,
+  useLeagueTeams,
+} from '@hcc/api';
+import { CalendarIcon } from '@hcc/icons';
+import {
+  Button,
+  Calendar,
+  Form,
+  FormControl,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormMessage,
+  Icon,
+  Input,
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+  toast,
+  Toaster,
+} from '@hcc/ui';
+import { zodResolver } from '@hookform/resolvers/zod';
+import { useRouter } from 'next/navigation';
+import { useEffect, useState } from 'react';
+import { useForm } from 'react-hook-form';
+import { z } from 'zod';
+
+import Layout from '@/components/Layout';
+import { formatTime } from '@/utils/time';
+
+import TimeInput from './_components/time-input';
+import {
+  getStateByQuarter,
+  QUARTER_ID,
+  QUARTER_KEY,
+  QUARTERS_DB,
+} from './_constants';
+import * as styles from './styles.css';
+
+const registerGameFormSchema = z.object({
+  name: z.string().min(1, { message: '경기 이름을 입력해주세요.' }),
+  round: z.string().min(1, { message: '라운드를 입력해주세요.' }),
+  quarter: z.string().min(1, {
+    message: '쿼터를 입력해주세요.',
+  }),
+  startDate: z.date({ message: '시작일을 입력해주세요' }),
+  startTime: z.string().min(1, { message: '시작 시간을 입력해주세요' }),
+  idOfTeam1: z.string().min(1, { message: '홈팀을 입력해주세요.' }),
+  idOfTeam2: z.string().min(1, { message: '원정팀을 입력해주세요.' }),
+  videoId: z.string().nullable(),
+  // playersOfTeam1: z.string().array(),
+  // playersOfTeam2: z.string().array(),
+});
+
+const defaultValues = {
+  name: '',
+  round: '',
+  quarter: '경기전',
+  startDate: new Date(),
+  startTime: '',
+  idOfTeam1: '',
+  idOfTeam2: '',
+  videoId: '',
+  // playersOfTeam1: [],
+  // playersOfTeam2: [],
+};
+
+export type RegisterGameFormSchema = z.infer<typeof registerGameFormSchema>;
+
+type PageProps = {
+  params: { leagueId: string };
+};
+
+export default function Page({ params }: PageProps) {
+  const [selectedTeamNames, setSelectedTeamNames] = useState<[string, string]>([
+    '',
+    '',
+  ]);
+  const [team1, setTeam1] = useState<string>('');
+  const [team2, setTeam2] = useState<string>('');
+
+  const router = useRouter();
+
+  const methods = useForm<RegisterGameFormSchema>({
+    resolver: zodResolver(registerGameFormSchema),
+    defaultValues,
+  });
+
+  // 리그팀 목록 조회 -> 선택한 리그팀 선수 조회 -> 선발, 후보 결정
+  const { data: leagueTeams } = useLeagueTeams(params.leagueId);
+  const { mutate: createGameMutate } = useCreateGame({
+    leagueId: params.leagueId,
+  });
+
+  const onSubmit = ({ startTime, ...data }: RegisterGameFormSchema) => {
+    const quarter = data.quarter as QUARTER_KEY;
+    const request: Omit<
+      RegisterGameFormSchema,
+      'startTime' | 'idOfTeam1' | 'idOfTeam2' | 'quarter'
+    > & {
+      leagueId: string;
+      idOfTeam1: number;
+      idOfTeam2: number;
+      quarter: number;
+      state: StateType;
+      round: LegacyRoundType;
+    } = {
+      ...data,
+      idOfTeam1: Number(data.idOfTeam1),
+      idOfTeam2: Number(data.idOfTeam2),
+      leagueId: params.leagueId,
+      round: data.round as LegacyRoundType,
+      startDate: new Date(
+        `${data.startDate.toLocaleDateString()}:${startTime}`,
+      ),
+      quarter: QUARTER_ID[quarter],
+      state: getStateByQuarter(quarter),
+    };
+
+    createGameMutate(request, {
+      // TODO 선수 등록으로 이동
+      onSuccess: () => {
+        router.replace('');
+      },
+    });
+
+    toast({
+      title: '대회 정보 수정 메시지',
+      description: (
+        <div>
+          <div>data.name: {data.name}</div>
+          <div>data.round: {data.round}</div>
+          <div>data.quarter: {data.quarter}</div>
+          <div>data.state: {QUARTER_ID[data.quarter as QUARTER_KEY]}</div>
+          <div>data.startDate: {data.startDate.toLocaleDateString()}</div>
+          <div>data.startTime: {startTime}</div>
+          <div>data.startTime: {data.idOfTeam1}</div>
+          <div>data.startTime: {data.idOfTeam2}</div>
+        </div>
+      ),
+    });
+    // TODO: API 호출 구현 필요
+  };
+
+  useEffect(() => {
+    const nextSelectedTeamNames: [string, string] = [
+      leagueTeams?.find(team => team.leagueTeamId === Number(team1))
+        ?.teamName || '',
+      leagueTeams?.find(team => team.leagueTeamId === Number(team2))
+        ?.teamName || '',
+    ];
+
+    setSelectedTeamNames(nextSelectedTeamNames);
+  }, [leagueTeams, team1, team2]);
+
+  return (
+    <Layout navigationTitle="새로운 경기 생성">
+      <section className={styles.page}>
+        <Form {...methods}>
+          <form
+            onSubmit={methods.handleSubmit(onSubmit)}
+            className={styles.form}
+          >
+            <div className={styles.block}>
+              <h2 className={styles.title}>경기 정보</h2>
+              <FormField
+                control={methods.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>경기 이름</FormLabel>
+                    <FormControl>
+                      <Input type="text" {...field} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={methods.control}
+                name="round"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormLabel>라운드</FormLabel>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue>{field.value}</SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        <SelectItem value="32강">32강</SelectItem>
+                        <SelectItem value="16강">16강</SelectItem>
+                        <SelectItem value="8강">8강</SelectItem>
+                        <SelectItem value="4강">4강</SelectItem>
+                        <SelectItem value="결승">결승</SelectItem>
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={methods.control}
+                name="quarter"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select
+                      onValueChange={field.onChange}
+                      defaultValue={field.value}
+                    >
+                      <FormLabel>쿼터</FormLabel>
+                      <FormControl>
+                        <SelectTrigger>
+                          <SelectValue>{field.value}</SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {Object.entries(QUARTERS_DB).map(([quarter, value]) => (
+                          <SelectItem key={quarter} value={value}>
+                            {quarter}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={methods.control}
+                name="startDate"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>시작일</FormLabel>
+                    <Popover>
+                      <PopoverTrigger asChild>
+                        <FormControl>
+                          <Button
+                            colorScheme="outline"
+                            fullWidth
+                            justify="between"
+                            style={{ borderColor: '#F3F3F5' }}
+                          >
+                            <span>
+                              {field.value
+                                ? formatTime(field.value, 'YYYY년 MM월 DD일')
+                                : ''}
+                            </span>
+                            <Icon source={CalendarIcon} />
+                          </Button>
+                        </FormControl>
+                      </PopoverTrigger>
+                      <PopoverContent align="start">
+                        <Calendar
+                          defaultValue={field.value}
+                          onChange={field.onChange}
+                        />
+                      </PopoverContent>
+                    </Popover>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={methods.control}
+                name="startTime"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>시작 시간</FormLabel>
+                    <FormControl>
+                      <TimeInput type="time" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className={styles.block}>
+              <h2 className={styles.title}>참가 팀</h2>
+              <FormField
+                control={methods.control}
+                name="idOfTeam1"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select
+                      onValueChange={team => {
+                        setTeam1(team);
+                        field.onChange(team);
+                      }}
+                      defaultValue={field.value}
+                    >
+                      <FormLabel>팀 선택 1</FormLabel>
+                      <FormControl>
+                        <SelectTrigger caret={false}>
+                          <SelectValue>{selectedTeamNames[0]}</SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {leagueTeams?.map(team => (
+                          <SelectItem
+                            key={team.leagueTeamId}
+                            value={`${team.leagueTeamId}`}
+                          >
+                            {team.teamName}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+
+              <FormField
+                control={methods.control}
+                name="idOfTeam2"
+                render={({ field }) => (
+                  <FormItem>
+                    <Select
+                      onValueChange={team => {
+                        setTeam2(team);
+                        field.onChange(team);
+                      }}
+                      defaultValue={field.value}
+                    >
+                      <FormLabel>팀 선택 2</FormLabel>
+                      <FormControl>
+                        <SelectTrigger caret={false}>
+                          <SelectValue>{selectedTeamNames[1]}</SelectValue>
+                        </SelectTrigger>
+                      </FormControl>
+                      <SelectContent>
+                        {leagueTeams?.map(team => (
+                          <SelectItem
+                            key={team.leagueTeamId}
+                            value={`${team.leagueTeamId}`}
+                          >
+                            <div>{team.teamName}</div>
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <div className={styles.block}>
+              <h2 className={styles.title}>영상</h2>
+              <FormField
+                control={methods.control}
+                name="videoId"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>영상</FormLabel>
+                    <FormControl>
+                      <Input type="text" {...field} value={field.value || ''} />
+                    </FormControl>
+                  </FormItem>
+                )}
+              />
+            </div>
+
+            <Button type="submit" fullWidth>
+              제출
+            </Button>
+          </form>
+        </Form>
+
+        <Toaster />
+      </section>
+    </Layout>
+  );
+}

--- a/apps/manager/app/league/[leagueId]/register-game/styles.css.ts
+++ b/apps/manager/app/league/[leagueId]/register-game/styles.css.ts
@@ -1,0 +1,26 @@
+import { rem, theme } from '@hcc/styles';
+import { style } from '@vanilla-extract/css';
+
+export const page = style({
+  padding: theme.sizes.appInlinePadding,
+  backgroundColor: theme.colors.white,
+});
+
+export const form = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(24),
+});
+
+export const block = style({
+  display: 'flex',
+  flexDirection: 'column',
+  gap: rem(12),
+});
+
+export const title = style({
+  color: theme.colors.gray900,
+  fontWeight: 600,
+
+  marginBottom: rem(6),
+});

--- a/apps/manager/app/league/_components/LeagueCard/index.tsx
+++ b/apps/manager/app/league/_components/LeagueCard/index.tsx
@@ -16,17 +16,17 @@ const LeagueCard = () => {
     <>
       {leagues?.map(({ leagueId, league }, index) => {
         const state: StateType = league.isInProgress
-          ? 'playing'
+          ? 'PLAYING'
           : league.maxRound === league.inProgressRound
-            ? 'scheduled'
-            : 'finished';
+            ? 'SCHEDULED'
+            : 'FINISHED';
 
         return (
           <Fragment key={leagueId}>
             <Card.Root>
               <div className={styles.leagueHeader}>
                 <Tag
-                  colorScheme={state === 'playing' ? 'primary' : 'secondary'}
+                  colorScheme={state === 'PLAYING' ? 'primary' : 'secondary'}
                 >
                   {stateMap[state]}
                 </Tag>

--- a/apps/manager/app/page.tsx
+++ b/apps/manager/app/page.tsx
@@ -32,7 +32,7 @@ export default function Page() {
       <Divider height={6} />
 
       <Suspense fallback={<Spinner />}>
-        <MatchOverview state="finished" />
+        <MatchOverview state="FINISHED" />
       </Suspense>
     </Layout>
   );

--- a/apps/spectator/app/_components/GameList/GameList.css.ts
+++ b/apps/spectator/app/_components/GameList/GameList.css.ts
@@ -40,9 +40,9 @@ const cardBase = style({
 });
 
 export const cardRoot = styleVariants({
-  playing: [cardBase],
-  scheduled: [cardBase],
-  finished: [
+  PLAYING: [cardBase],
+  SCHEDULED: [cardBase],
+  FINISHED: [
     cardBase,
     {
       filter: 'opacity(0.6)',
@@ -74,21 +74,21 @@ const timeStampBase = style({
 });
 
 export const timeStamp = styleVariants({
-  playing: [
+  PLAYING: [
     timeStampBase,
     {
       color: theme.colors.white,
       backgroundColor: theme.colors.indicatorRed[3],
     },
   ],
-  scheduled: [
+  SCHEDULED: [
     timeStampBase,
     {
       color: theme.colors.primary[3],
       backgroundColor: theme.colors.primary[1],
     },
   ],
-  finished: [
+  FINISHED: [
     timeStampBase,
     {
       color: theme.colors.gray[4],

--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -62,7 +62,7 @@ export default function GameInfo({ gameTeams, gameId, state }: GameInfoProps) {
 }
 
 function GameScore({ score, state }: { score: number; state: GameState }) {
-  if (state === 'scheduled') return null;
+  if (state === 'SCHEDULED') return null;
 
   return <span className={styles.gameInfoRow.score}>{score}</span>;
 }

--- a/apps/spectator/constants/configs.ts
+++ b/apps/spectator/constants/configs.ts
@@ -5,13 +5,13 @@ export const TABS_CONFIG = {
 } as const;
 
 export const GAME_STATE = {
-  SCHEDULED: 'scheduled',
-  PLAYING: 'playing',
-  FINISHED: 'finished',
+  SCHEDULED: 'SCHEDULED',
+  PLAYING: 'PLAYING',
+  FINISHED: 'FINISHED',
 } as const;
 
 export const GAME_STATE_KR = {
-  scheduled: '예정',
-  playing: '진행 중',
-  finished: '종료',
+  SCHEDULED: '예정',
+  PLAYING: '진행 중',
+  FINISHED: '종료',
 } as const;

--- a/packages/api/src/mutations/index.tsx
+++ b/packages/api/src/mutations/index.tsx
@@ -1,3 +1,4 @@
+import useCreateGame from './useCreateGames';
 import useCreateLeague from './useCreateLeague';
 import useCreateLeagueTeam from './useCreateLeagueTeam';
 import useDeleteLeague from './useDeleteLeague';
@@ -18,4 +19,5 @@ export {
   useUpdateLeague,
   useUpdateLeagueTeam,
   useUploadImage,
+  useCreateGame,
 };

--- a/packages/api/src/mutations/useCreateGames.ts
+++ b/packages/api/src/mutations/useCreateGames.ts
@@ -1,0 +1,41 @@
+import {
+  MutationOptions,
+  useMutation,
+  useQueryClient,
+} from '@tanstack/react-query';
+
+import { fetcher } from '../fetcher';
+import { CreateGameType } from '../types';
+
+type LeagueId = { leagueId: string };
+type Request = CreateGameType & LeagueId;
+
+const postCreateGame = (request: Request) => {
+  const { leagueId, ...rest } = request;
+
+  return fetcher.post(`/leagues/${leagueId}/games`, rest);
+};
+
+type UseCreateGameRequest = Omit<
+  MutationOptions<unknown, Error, Request, unknown>,
+  'mutationFn'
+> &
+  LeagueId;
+
+const useCreateGame = ({ leagueId, ...options }: UseCreateGameRequest) => {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: postCreateGame,
+    onSuccess: async (data, variables, context) => {
+      await queryClient.invalidateQueries({
+        queryKey: ['gamesByLeagueList', { leagueId, state: variables.state }],
+      });
+
+      if (options.onSuccess) options.onSuccess(data, variables, context);
+    },
+    ...options,
+  });
+};
+
+export default useCreateGame;

--- a/packages/api/src/queries/index.tsx
+++ b/packages/api/src/queries/index.tsx
@@ -5,6 +5,7 @@ import useLeague from './useLeague';
 import useLeagues from './useLeagues';
 import useLeaguesDetail from './useLeaguesDetail';
 import useLeagueTeam from './useLeagueTeam';
+import useLeagueTeamDetail from './useLeagueTeamDetail';
 import useLeagueTeamPlayers from './useLeagueTeamPlayers';
 import useLeagueTeams from './useLeagueTeams';
 
@@ -18,4 +19,5 @@ export {
   useLeagueTeam,
   useLeagueTeamPlayers,
   useLeagueTeams,
+  useLeagueTeamDetail,
 };

--- a/packages/api/src/queries/useLeagueTeamDetail.ts
+++ b/packages/api/src/queries/useLeagueTeamDetail.ts
@@ -1,0 +1,9 @@
+import { useSuspenseQuery } from '@tanstack/react-query';
+
+import { queryKeys } from '../queryKey';
+
+const useLeagueTeamDetail = (teamId: string) => {
+  return useSuspenseQuery(queryKeys.leagueTeamDetail(teamId));
+};
+
+export default useLeagueTeamDetail;

--- a/packages/api/src/queryKey.ts
+++ b/packages/api/src/queryKey.ts
@@ -9,6 +9,7 @@ import {
   LeagueType,
   StateType,
   TeamPlayerType,
+  TeamDetailType,
   TeamType,
 } from './types';
 
@@ -62,6 +63,12 @@ const leagueQueryKeys = {
     queryKey: ['leagueTeamPlayers', { leagueTeamId }],
     queryFn: () =>
       fetcher.get<TeamPlayerType[]>(`/leagues/teams/${leagueTeamId}/players`),
+  }),
+
+  leagueTeamDetail: (leagueTeamId: string) => ({
+    queryKey: ['leagueTeamDetail', { leagueTeamId }],
+    queryFn: () =>
+      fetcher.get<TeamDetailType>(`/leagues/teams/${leagueTeamId}`),
   }),
 };
 

--- a/packages/api/src/types/game.ts
+++ b/packages/api/src/types/game.ts
@@ -1,12 +1,26 @@
 import { LeagueListType } from './league';
 
 export const stateMap = {
-  playing: '진행 중',
-  scheduled: '시작 전',
-  finished: '종료',
+  PLAYING: '진행 중',
+  SCHEDULED: '시작 전',
+  FINISHED: '종료',
 } as const;
 
 export type StateType = keyof typeof stateMap;
+
+export type RoundType = 32 | 16 | 8 | 4;
+export type LegacyRoundType = `${RoundType}강` | '결승';
+
+export type CreateGameType = {
+  name: string;
+  round: LegacyRoundType;
+  quarter: number;
+  state: StateType;
+  startDate: Date;
+  idOfTeam1: number;
+  idOfTeam2: number;
+  videoId: string | null;
+};
 
 export type GameTeamType = {
   gameTeamId: number;

--- a/packages/api/src/types/team.ts
+++ b/packages/api/src/types/team.ts
@@ -31,3 +31,9 @@ export type TeamUpdateType = {
   updatedPlayers: TeamPlayerType[];
   deletedPlayerIds: number[];
 };
+
+export type TeamDetailType = {
+  logoImageUrl: string;
+  teamName: string;
+  leagueTeamPlayers: (TeamPlayerType & { id: number })[];
+};

--- a/packages/ui/src/bottom-sheet/styles.css.ts
+++ b/packages/ui/src/bottom-sheet/styles.css.ts
@@ -14,7 +14,6 @@ export const overlay = style({
 export const content = style({
   display: 'flex',
   flexDirection: 'column',
-  height: 'auto',
 
   position: 'fixed',
   bottom: 0,
@@ -29,6 +28,7 @@ export const content = style({
 });
 
 export const bar = style({
+  flexShrink: 0,
   margin: '0 auto',
   marginTop: rem(16),
   height: rem(6),

--- a/packages/ui/src/form/styles.css.ts
+++ b/packages/ui/src/form/styles.css.ts
@@ -56,6 +56,10 @@ globalStyle(`${label}:has(+ div > input:focus)`, {
   transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
 });
 
+globalStyle(`${label}:has(+ div > input[type="time"])`, {
+  transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
+});
+
 globalStyle(`${label}:has(+ ${control}:where(button[data-state="open"]))`, {
   transform: 'scale(.85) translateY(-.5rem) translateX(.25rem)',
 });

--- a/packages/ui/src/select/select.tsx
+++ b/packages/ui/src/select/select.tsx
@@ -16,17 +16,21 @@ const SelectValue = SelectPrimitive.Value;
 
 const SelectTrigger = forwardRef<
   ElementRef<typeof SelectPrimitive.Trigger>,
-  ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger>
->(({ className, children, ...props }, ref) => (
+  ComponentPropsWithoutRef<typeof SelectPrimitive.Trigger> & {
+    caret?: boolean;
+  }
+>(({ caret = true, className, children, ...props }, ref) => (
   <SelectPrimitive.Trigger
     ref={ref}
     className={clsx(styles.trigger, className)}
     {...props}
   >
     {children}
-    <SelectPrimitive.Icon asChild>
-      <Icon source={CaretDownIcon} width={24} height={24} color="gray" />
-    </SelectPrimitive.Icon>
+    {caret && (
+      <SelectPrimitive.Icon asChild>
+        <Icon source={CaretDownIcon} width={24} height={24} color="gray" />
+      </SelectPrimitive.Icon>
+    )}
   </SelectPrimitive.Trigger>
 ));
 SelectTrigger.displayName = SelectPrimitive.Trigger.displayName;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

## ✅ 작업 내용

- 리그 경기 생성 페이지 추가
- 피그마 상에는 경기 생성 시 라인업 등록 버튼이 표시되도록 되어 있지만 로직 상 불가능하여 일단 제거하고 새로운 페이지로 리다이렉트 시켜야 할 것 같음
  - 이유는, 라인업 등록 여부를 판단하기 위해서 리그 경기의 ID를 불러와야 하는데, 경기 생성 페이지에서는 그게 어려움
  - 그래서 [gameId]와 같은 다이나믹 라우팅으로 이동시켜야 할 듯
- 제출 버튼을 누르면 401 권한 에러가 발생하고 있는데, 이 부분은 백엔드와 함께 이야기 해서 해결해야 할 것으로 보임

## 📝 참고 자료

- 작업한 내용에 대한 부연 설명

## ♾️ 기타

- 추가로 필요한 작업 내용
