### PR TITLE
fix: 경기 수정 시 라운드 타입 불일치 해결

### DIFF
--- a/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
@@ -1,10 +1,5 @@
 'use client';
-import {
-  LegacyRoundType,
-  useDeleteGame,
-  useGame,
-  useUpdateGame,
-} from '@hcc/api';
+import { useDeleteGame, useGame, useUpdateGame } from '@hcc/api';
 import { useToast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
@@ -59,12 +54,7 @@ export default function Page({ params }: PageProps) {
     if (game) {
       methods.reset({
         name: game.gameName,
-        round:
-          game.round.toString() === 'FINAL'
-            ? '결승'
-            : game.round.toString() === 'SEMI_FINAL'
-              ? '4강'
-              : game.round.toString().replace('ROUND_', '') + '강',
+        round: game.round.toString(),
         quarter: game.gameQuarter,
         startDate: new Date(formatTime(new Date(game.startTime), 'YYYY-MM-DD')),
         startTime: formatTime(new Date(game.startTime), 'HH:mm'),
@@ -83,7 +73,7 @@ export default function Page({ params }: PageProps) {
         leagueId,
         gameId,
         name: data.name,
-        round: data.round as LegacyRoundType,
+        round: Number(data.round),
         quarter: quarter,
         state: getStateByQuarter(quarter),
         startTime: `${formatTime(data.startDate, 'YYYY-MM-DD')}T${data.startTime}:00`,

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ReplacementForm.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ReplacementForm.tsx
@@ -3,7 +3,6 @@ import {
   useCreateReplacementTimeline,
   useGame,
   useGameLineup,
-  useGameLineupPlaying,
 } from '@hcc/api';
 import {
   Button,
@@ -51,7 +50,6 @@ const ReplacementForm = ({
   const teams: GameTeamType[] = game?.gameTeams ?? [];
 
   const { data: lineupPlayers } = useGameLineup(gameId);
-  const { data: lineupPlayingPlayers } = useGameLineupPlaying(gameId);
 
   const methods = useForm<ReplacementFormSchema>({
     resolver: zodResolver(replacementFormSchema),
@@ -90,16 +88,16 @@ const ReplacementForm = ({
   const players = useMemo(() => {
     return (
       lineupPlayers?.find(lineup => lineup.gameTeamId.toString() === gameTeamId)
-        ?.gameTeamPlayers ?? []
+        ?.candidatePlayers ?? []
     );
   }, [lineupPlayers, gameTeamId]);
+
   const playingPlayers = useMemo(() => {
     return (
-      lineupPlayingPlayers?.find(
-        lineup => lineup.gameTeamId.toString() === gameTeamId,
-      )?.gameTeamPlayers ?? []
+      lineupPlayers?.find(lineup => lineup.gameTeamId.toString() === gameTeamId)
+        ?.starterPlayers ?? []
     );
-  }, [lineupPlayingPlayers, gameTeamId]);
+  }, [lineupPlayers, gameTeamId]);
 
   useEffect(() => {
     methods.setValue('originLineupPlayerId', '');

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
@@ -73,6 +73,8 @@ export const GameForm = ({
     return [];
   };
 
+  if (!league || !teams) return null;
+
   return (
     <Form {...methods}>
       <form className={styles.form} onSubmit={methods.handleSubmit(onSubmit)}>
@@ -117,7 +119,7 @@ export const GameForm = ({
                       { value: '4', label: '4강', round: 4 },
                       { value: '2', label: '결승', round: 2 },
                     ]
-                      .filter(item => league?.maxRound >= item.round)
+                      .filter(item => league.maxRound >= item.round)
                       .map(item => (
                         <SelectItem key={item.value} value={item.value}>
                           {item.label}

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
@@ -1,4 +1,4 @@
-import { useGame, useLeague, useLeagueTeams } from '@hcc/api';
+import { useGame, useLeague, useLeagueTeams, ROUND_OPTIONS } from '@hcc/api';
 import { CalendarIcon } from '@hcc/icons';
 import {
   Button,
@@ -112,19 +112,13 @@ export const GameForm = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {[
-                      { value: '32', label: '32강', round: 32 },
-                      { value: '16', label: '16강', round: 16 },
-                      { value: '8', label: '8강', round: 8 },
-                      { value: '4', label: '4강', round: 4 },
-                      { value: '2', label: '결승', round: 2 },
-                    ]
-                      .filter(item => league.maxRound >= item.round)
-                      .map(item => (
-                        <SelectItem key={item.value} value={item.value}>
-                          {item.label}
-                        </SelectItem>
-                      ))}
+                    {ROUND_OPTIONS.filter(
+                      item => league.maxRound >= item.round,
+                    ).map(item => (
+                      <SelectItem key={item.value} value={item.value}>
+                        {item.label}
+                      </SelectItem>
+                    ))}
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
@@ -1,4 +1,4 @@
-import { useGame, useLeagueTeams } from '@hcc/api';
+import { useGame, useLeague, useLeagueTeams } from '@hcc/api';
 import { CalendarIcon } from '@hcc/icons';
 import {
   Button,
@@ -23,7 +23,7 @@ import {
 import { SubmitHandler, UseFormReturn } from 'react-hook-form';
 
 import TimeInput from '@/components/TimeInput';
-import { QUARTER_KEY, QUARTERS_DB } from '@/constants/games';
+import { QUARTERS_DB } from '@/constants/games';
 import { formatTime } from '@/utils/time';
 
 import * as styles from './styles.css';
@@ -47,6 +47,7 @@ export const GameForm = ({
   onSubmit,
   type,
 }: GameFormProps) => {
+  const { data: league } = useLeague(leagueId);
   const { data: teams } = useLeagueTeams(leagueId);
   const { data: game } = useGame(gameId);
 
@@ -109,11 +110,19 @@ export const GameForm = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="32">32강</SelectItem>
-                    <SelectItem value="16">16강</SelectItem>
-                    <SelectItem value="8">8강</SelectItem>
-                    <SelectItem value="4">4강</SelectItem>
-                    <SelectItem value="2">결승</SelectItem>
+                    {[
+                      { value: '32', label: '32강', round: 32 },
+                      { value: '16', label: '16강', round: 16 },
+                      { value: '8', label: '8강', round: 8 },
+                      { value: '4', label: '4강', round: 4 },
+                      { value: '2', label: '결승', round: 2 },
+                    ]
+                      .filter(item => league?.maxRound >= item.round)
+                      .map(item => (
+                        <SelectItem key={item.value} value={item.value}>
+                          {item.label}
+                        </SelectItem>
+                      ))}
                   </SelectContent>
                 </Select>
                 <FormMessage />
@@ -133,14 +142,12 @@ export const GameForm = ({
                   <FormLabel>쿼터</FormLabel>
                   <FormControl>
                     <SelectTrigger>
-                      <SelectValue>
-                        {QUARTERS_DB[field.value as QUARTER_KEY]}
-                      </SelectValue>
+                      <SelectValue>{field.value}</SelectValue>
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {Object.entries(QUARTERS_DB).map(([quarter, value]) => (
-                      <SelectItem key={quarter} value={quarter}>
+                    {Object.entries(QUARTERS_DB).map(([value]) => (
+                      <SelectItem key={value} value={value}>
                         {value}
                       </SelectItem>
                     ))}

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
@@ -142,8 +142,8 @@ export const GameForm = ({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    {Object.entries(QUARTERS_DB).map(([value]) => (
-                      <SelectItem key={value} value={value}>
+                    {Object.entries(QUARTERS_DB).map(([quarter, value]) => (
+                      <SelectItem key={quarter} value={quarter}>
                         {value}
                       </SelectItem>
                     ))}

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/GameForm.tsx
@@ -102,15 +102,18 @@ export const GameForm = ({
                   <FormLabel>라운드</FormLabel>
                   <FormControl>
                     <SelectTrigger>
-                      <span>{field.value}</span>
+                      <span>
+                        {field.value &&
+                          (field.value === '2' ? '결승' : `${field.value}강`)}
+                      </span>
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
-                    <SelectItem value="32강">32강</SelectItem>
-                    <SelectItem value="16강">16강</SelectItem>
-                    <SelectItem value="8강">8강</SelectItem>
-                    <SelectItem value="4강">4강</SelectItem>
-                    <SelectItem value="결승">결승</SelectItem>
+                    <SelectItem value="32">32강</SelectItem>
+                    <SelectItem value="16">16강</SelectItem>
+                    <SelectItem value="8">8강</SelectItem>
+                    <SelectItem value="4">4강</SelectItem>
+                    <SelectItem value="2">결승</SelectItem>
                   </SelectContent>
                 </Select>
                 <FormMessage />

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/types.ts
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/types.ts
@@ -16,7 +16,7 @@ export type GameFormSchema = z.infer<typeof gameFormSchema>;
 export const gameDefaultValues = {
   name: '',
   round: '',
-  quarter: '경기전',
+  quarter: '경기 전',
   startDate: new Date(),
   startTime: '',
   idOfTeam1: '',

--- a/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
@@ -34,7 +34,7 @@ const LeagueOverview = ({ leagueId }: LeagueOverviewProps) => {
       </div>
       <Card.Content marginTop={12} gap={10}>
         <p className={styles.description}>
-          <strong>라운드</strong>&nbsp;{league.maxRound}
+          <strong>라운드</strong>&nbsp;{league.maxRound}강
         </p>
         <p className={styles.description}>
           <strong>기간</strong>&nbsp;

--- a/apps/manager/app/league/[leagueId]/_components/LineupSheet/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/LineupSheet/index.tsx
@@ -1,6 +1,5 @@
 import {
   useGameLineup,
-  useGameLineupPlaying,
   GameTeamPlayerType,
   useUpdateLineupStarter,
   useUpdateLineupCandidate,
@@ -41,24 +40,18 @@ const LineupSheet = ({ gameId, teamId }: LineupUpdateSheetProps) => {
 
   const { data: game } = useGame(gameId);
   const { data: lineupList } = useGameLineup(gameId);
-  const { data: lineupPlayingList } = useGameLineupPlaying(gameId);
 
   const teamName: string =
     game?.gameTeams.find(gameTeam => gameTeam.gameTeamId === Number(teamId))
       ?.gameTeamName || '';
 
-  const currentLineup = lineupList?.find(
-    lineup => lineup.gameTeamId === Number(teamId),
-  );
-
   const currentPlayingLineup: GameTeamPlayerType[] =
-    lineupPlayingList?.find(lineup => lineup.gameTeamId === Number(teamId))
-      ?.gameTeamPlayers || [];
+    lineupList?.find(lineup => lineup.gameTeamId === Number(teamId))
+      ?.starterPlayers || [];
 
   const candidateLineup: GameTeamPlayerType[] =
-    currentLineup?.gameTeamPlayers.filter(
-      player => !currentPlayingLineup.some(p => p.id === player.id),
-    ) || [];
+    lineupList?.find(lineup => lineup.gameTeamId === Number(teamId))
+      ?.candidatePlayers || [];
 
   const {
     mutate: updateLineupCaptainRegister,

--- a/apps/manager/app/league/[leagueId]/manage/page.tsx
+++ b/apps/manager/app/league/[leagueId]/manage/page.tsx
@@ -55,17 +55,20 @@ export default function Page({ params }: PageProps) {
       {
         leagueId,
         name: leagueName,
-        maxRound: `${round}강`,
+        maxRound: round,
         startAt: formatTime(startDate, 'YYYY-MM-DDTHH:mm:ss'),
         endAt: formatTime(endDate, 'YYYY-MM-DDTHH:mm:ss'),
       },
       {
         onSuccess: () => {
-          toast({ title: '팀 정보가 수정되었습니다', variant: 'destructive' });
+          toast({
+            title: '대회 정보가 수정되었습니다',
+            variant: 'destructive',
+          });
         },
         onError: () => {
           toast({
-            title: '팀 정보 수정에 실패했습니다',
+            title: '대회 정보 수정에 실패했습니다',
             variant: 'destructive',
           });
         },

--- a/apps/manager/app/league/[leagueId]/register-game/page.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { LegacyRoundType, useCreateGame } from '@hcc/api';
+import { useCreateGame } from '@hcc/api';
 import { useToast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
@@ -44,7 +44,7 @@ export default function Page({ params }: PageProps) {
       {
         leagueId,
         name: data.name,
-        round: data.round as LegacyRoundType,
+        round: Number(data.round),
         quarter: quarter,
         state: getStateByQuarter(quarter),
         startTime: `${formatTime(data.startDate, 'YYYY-MM-DD')}T${data.startTime}:00`,

--- a/apps/manager/constants/games.ts
+++ b/apps/manager/constants/games.ts
@@ -2,11 +2,11 @@ import { StateType } from '@hcc/api';
 import { ProgressType } from '@hcc/api/src';
 
 export const QUARTERS_DB = {
-  경기전: '경기 전',
+  경기전: '경기전',
   전반전: '전반전',
   후반전: '후반전',
   승부차기: '승부차기',
-  경기후: '경기 종료',
+  '경기 종료': '경기 종료',
   연장전: '연장전',
 } as const;
 
@@ -15,7 +15,7 @@ export const QUARTER_ID: Record<QUARTER_KEY, number> = {
   후반전: 5,
   경기전: 6,
   승부차기: 7,
-  경기후: 8,
+  '경기 종료': 8,
   연장전: 9,
 } as const;
 
@@ -23,7 +23,7 @@ export type QUARTER_KEY = keyof typeof QUARTERS_DB;
 
 export const getStateByQuarter = (quarter: QUARTER_KEY): StateType => {
   if (quarter === '경기전') return 'SCHEDULED';
-  if (quarter === '경기후') return 'FINISHED';
+  if (quarter === '경기 종료') return 'FINISHED';
 
   return 'PLAYING';
 };
@@ -38,7 +38,7 @@ export const getProgressTypeByQuarter = (
       return 'QUARTER_START';
     case '승부차기':
       return 'QUARTER_START';
-    case '경기후':
+    case '경기 종료':
       return 'GAME_END';
     default:
       return 'GAME_END';

--- a/packages/api/src/queryKey.ts
+++ b/packages/api/src/queryKey.ts
@@ -18,6 +18,7 @@ import {
   CheerTalkType,
   LeagueCheerTalkPayload,
   GameCheerTalkPayload,
+  PlayingLineupType,
 } from './types';
 
 const managerQueryKeys = {
@@ -132,7 +133,8 @@ const gameQueryKeys = {
 
   lineupPlaying: (gameId: string) => ({
     queryKey: ['gameLineupPlaying', { gameId }],
-    queryFn: () => fetcher.get<LineupType[]>(`/games/${gameId}/lineup/playing`),
+    queryFn: () =>
+      fetcher.get<PlayingLineupType[]>(`/games/${gameId}/lineup/playing`),
   }),
 };
 

--- a/packages/api/src/types/game.ts
+++ b/packages/api/src/types/game.ts
@@ -70,3 +70,9 @@ export type LineupType = {
   starterPlayers: GameTeamPlayerType[];
   candidatePlayers: GameTeamPlayerType[];
 };
+
+export type PlayingLineupType = {
+  gameTeamId: number;
+  teamName: string;
+  gameTeamPlayers: GameTeamPlayerType[];
+};

--- a/packages/api/src/types/game.ts
+++ b/packages/api/src/types/game.ts
@@ -9,12 +9,9 @@ export const stateMap = {
 export type StateType = keyof typeof stateMap;
 export type StateValueType = (typeof stateMap)[keyof typeof stateMap];
 
-export type RoundType = 32 | 16 | 8 | 4;
-export type LegacyRoundType = `${RoundType}강` | '결승';
-
 export type CreateGameType = {
   name: string;
-  round: LegacyRoundType;
+  round: number;
   quarter: string;
   state: StateType;
   startTime: string;
@@ -36,7 +33,7 @@ export type GameType = {
   startTime: Date;
   gameQuarter: string;
   gameName: string;
-  round: string;
+  round: number;
   videoId?: string;
   gameTeams: GameTeamType[];
   sportsName: string;
@@ -64,11 +61,12 @@ export type GameTeamPlayerType = {
   description?: string;
   number: number;
   isCaptain: boolean;
-  state: string;
+  state: 'STARTER' | 'CANDIDATE';
 };
 
 export type LineupType = {
   gameTeamId: number;
   teamName: string;
-  gameTeamPlayers: GameTeamPlayerType[];
+  starterPlayers: GameTeamPlayerType[];
+  candidatePlayers: GameTeamPlayerType[];
 };

--- a/packages/api/src/types/league.ts
+++ b/packages/api/src/types/league.ts
@@ -49,3 +49,11 @@ export type ManagerManageLeagueType = Omit<
   sizeOfLeagueTeams: number;
   maxRound: string;
 };
+
+export const ROUND_OPTIONS = [
+  { value: '32', label: '32강', round: 32 },
+  { value: '16', label: '16강', round: 16 },
+  { value: '8', label: '8강', round: 8 },
+  { value: '4', label: '4강', round: 4 },
+  { value: '2', label: '결승', round: 2 },
+] as const;


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #326

## ✅ 작업 내용

- 경기 생성 및 수정 시 라운드 형식 변경으로 인한 저장 오류를 해결했습니다.
- 선수 DTO 변경으로 인해 빌드가 정상적으로 이루어지지 않는 문제를 수정했습니다.
- 경기 생성 및 수정 시 라운드를 리그의 `maxRound`에 따라 필터(높은 라운드 선택 불가능)되게 변경했습니다. 
