### PR TITLE
chore: 매니저 앱 상세정보 텍스트 변경

### DIFF
--- a/apps/manager/app/league/[leagueId]/_components/GameCard/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/GameCard/index.tsx
@@ -31,11 +31,14 @@ const GameCard = ({ leagueId, state }: GameCardProps) => {
           <Fragment key={game.id}>
             <Card.Root>
               <Card.Head>
-                <Tag
-                  colorScheme={state === 'PLAYING' ? 'primary' : 'secondary'}
-                >
-                  {stateMap[state]}
-                </Tag>
+                <span className={styles.titleContainer}>
+                  <Tag
+                    colorScheme={state === 'PLAYING' ? 'primary' : 'secondary'}
+                  >
+                    {stateMap[state]}
+                  </Tag>
+                  <p>{game.gameName}</p>
+                </span>
                 {formatTime(game.startTime, 'YYYY.MM.DD. (ddd) HH:mm')}
               </Card.Head>
               <Card.Content marginTop={16} gap={8}>

--- a/apps/manager/app/league/[leagueId]/_components/GameCard/styles.css.ts
+++ b/apps/manager/app/league/[leagueId]/_components/GameCard/styles.css.ts
@@ -1,5 +1,5 @@
 import { rem, theme } from '@hcc/styles';
-import { style } from '@vanilla-extract/css';
+import { globalStyle, style } from '@vanilla-extract/css';
 
 export const stateContainer = style({
   paddingBlock: rem(16),
@@ -16,6 +16,17 @@ export const noGamesMessage = style({
   fontWeight: 500,
   textAlign: 'center',
   backgroundColor: theme.colors.white,
+});
+
+export const titleContainer = style({
+  ...theme.layouts.centerY,
+  gap: theme.spaces.xs,
+});
+
+globalStyle(`${titleContainer} > p`, {
+  color: theme.colors.gray400,
+  fontSize: rem(14),
+  fontWeight: 500,
 });
 
 export const gameDivider = style({

--- a/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
+++ b/apps/manager/app/league/[leagueId]/_components/LeagueOverview/index.tsx
@@ -29,7 +29,7 @@ const LeagueOverview = ({ leagueId }: LeagueOverviewProps) => {
       <div className={styles.headContainer}>
         <h3 className={styles.title}>{league.name}</h3>
         <Link className={styles.manageLink} href={`/league/${leagueId}/manage`}>
-          상세 정보
+          편집
         </Link>
       </div>
       <Card.Content marginTop={12} gap={10}>


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #337 

## ✅ 작업 내용

- 리그 상세 페이지에서 '상세정보'를 '편집'으로 변경했습니다.
- 매니저 페이지에서 게임 이름이 보이지 않아 불편해서 게임 이름을 추가했습니다.
<img width="300" alt="image" src="https://github.com/user-attachments/assets/99d25a1c-b80f-45e7-b827-2b5c39f27351">