### PR TITLE
fix: 매니저 대회 및 게임 생성 오류 수정

### DIFF
--- a/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
@@ -65,10 +65,12 @@ export default function Page({ params }: PageProps) {
     }
   }, [game, methods]);
 
-  const { mutate: updateGameMutation } = useUpdateGame();
+  const { mutate: updateGame, isPending } = useUpdateGame();
   const onSubmit = (data: GameFormSchema) => {
+    if (isPending) return;
+
     const quarter = data.quarter as QUARTER_KEY;
-    updateGameMutation(
+    updateGame(
       {
         leagueId,
         gameId,

--- a/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
@@ -106,6 +106,7 @@ export default function Page({ params }: PageProps) {
       {
         onSuccess: () => {
           toast({ title: '경기가 삭제되었습니다.', variant: 'destructive' });
+          router.replace(`/league/${leagueId}`);
         },
         onError: () => {
           toast({ title: '경기 삭제에 실패했습니다.', variant: 'destructive' });

--- a/apps/manager/app/league/[leagueId]/_components/GameForm/types.ts
+++ b/apps/manager/app/league/[leagueId]/_components/GameForm/types.ts
@@ -16,7 +16,7 @@ export type GameFormSchema = z.infer<typeof gameFormSchema>;
 export const gameDefaultValues = {
   name: '',
   round: '',
-  quarter: '경기 전',
+  quarter: '경기전',
   startDate: new Date(),
   startTime: '',
   idOfTeam1: '',

--- a/apps/manager/app/league/[leagueId]/_components/TeamForm/types.ts
+++ b/apps/manager/app/league/[leagueId]/_components/TeamForm/types.ts
@@ -25,9 +25,7 @@ export const teamFormSchema = z.object({
       { message: '로고를 추가해주세요' },
     ),
   name: z.string().min(1, { message: '팀명을 입력해주세요' }),
-  players: z
-    .array(teamPlayerSchema)
-    .nonempty({ message: '플레이어를 추가해주세요' }),
+  players: z.array(teamPlayerSchema),
 });
 
 export type TeamFormSchema = z.infer<typeof teamFormSchema>;

--- a/apps/manager/app/league/[leagueId]/cheer-talk/blocked/page.tsx
+++ b/apps/manager/app/league/[leagueId]/cheer-talk/blocked/page.tsx
@@ -14,7 +14,8 @@ type PageProps = {
 
 export default function Page({ params }: PageProps) {
   const { toast } = useToast();
-  const { mutate: updateCheerTalkUnblock } = useUpdateCheerTalkUnblock();
+  const { mutate: updateCheerTalkUnblock, isPending } =
+    useUpdateCheerTalkUnblock();
 
   const ActionButton = (cheerTalkId: number) => {
     return (
@@ -24,6 +25,8 @@ export default function Page({ params }: PageProps) {
         primaryActionLabel="해제"
         secondaryActionLabel="취소"
         onPrimaryAction={() => {
+          if (isPending) return;
+
           updateCheerTalkUnblock(
             { leagueId: params.leagueId, cheerTalkId },
             {

--- a/apps/manager/app/league/[leagueId]/cheer-talk/page.tsx
+++ b/apps/manager/app/league/[leagueId]/cheer-talk/page.tsx
@@ -21,7 +21,7 @@ type PageProps = {
 export default function Page({ params }: PageProps) {
   const leagueId: string = params.leagueId;
 
-  const { mutate: updateCheerTalkBlock } = useUpdateCheerTalkBlock();
+  const { mutate: updateCheerTalkBlock, isPending } = useUpdateCheerTalkBlock();
   const BlockButton = (cheerTalkId: number) => {
     return (
       <Button
@@ -29,6 +29,8 @@ export default function Page({ params }: PageProps) {
         size="xs"
         fullWidth
         onClick={() => {
+          if (isPending) return;
+
           updateCheerTalkBlock(
             { leagueId, cheerTalkId },
             {

--- a/apps/manager/app/league/[leagueId]/manage/page.tsx
+++ b/apps/manager/app/league/[leagueId]/manage/page.tsx
@@ -47,11 +47,13 @@ export default function Page({ params }: PageProps) {
     defaultValues: leagueDefaultValues,
   });
 
-  const { mutate: updateLeagueMutation } = useUpdateLeague();
+  const { mutate: updateLeague, isPending } = useUpdateLeague();
 
   const onSubmit = (data: LeagueFormSchema) => {
+    if (isPending) return;
+
     const { leagueName, round, startDate, endDate } = data;
-    updateLeagueMutation(
+    updateLeague(
       {
         leagueId,
         name: leagueName,

--- a/apps/manager/app/league/[leagueId]/register-game/page.tsx
+++ b/apps/manager/app/league/[leagueId]/register-game/page.tsx
@@ -31,9 +31,13 @@ export default function Page({ params }: PageProps) {
     defaultValues: gameDefaultValues,
   });
 
-  const { mutateAsync: createGameMutation } = useCreateGame({ leagueId });
+  const { mutateAsync: createGameMutation, isPending } = useCreateGame({
+    leagueId,
+  });
 
   const onSubmit = async (data: GameFormSchema) => {
+    if (isPending) return;
+
     if (data.idOfTeam1 === data.idOfTeam2) {
       toast({ title: '팀1과 팀2가 같을 수 없습니다', variant: 'destructive' });
       return;

--- a/apps/manager/app/league/[leagueId]/register-team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/register-team/page.tsx
@@ -36,6 +36,14 @@ export default function Page({ params }: PageProps) {
 
   const onSubmit = async (data: TeamFormSchema) => {
     if (isPending) return;
+
+    if (data.players.length < 1) {
+      return toast({
+        title: '선수를 최소 1명 이상 등록해주세요',
+        variant: 'destructive',
+      });
+    }
+
     let imageUrl: string;
     if (data.logo instanceof File) imageUrl = await uploadImage(data.logo);
     else imageUrl = data.logo;

--- a/apps/manager/app/league/[leagueId]/register-team/page.tsx
+++ b/apps/manager/app/league/[leagueId]/register-team/page.tsx
@@ -32,9 +32,10 @@ export default function Page({ params }: PageProps) {
     defaultValues: teamDefaultValues,
   });
 
-  const { mutate: createLeagueTeamMutation } = useCreateLeagueTeam();
+  const { mutate: createLeagueTeam, isPending } = useCreateLeagueTeam();
 
   const onSubmit = async (data: TeamFormSchema) => {
+    if (isPending) return;
     let imageUrl: string;
     if (data.logo instanceof File) imageUrl = await uploadImage(data.logo);
     else imageUrl = data.logo;
@@ -48,7 +49,7 @@ export default function Page({ params }: PageProps) {
       })),
     };
 
-    createLeagueTeamMutation(
+    createLeagueTeam(
       { leagueId, ...team },
       {
         onSuccess: () => {

--- a/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
@@ -71,14 +71,16 @@ export default function Page({ params }: PageProps) {
     }
   }, [methods, team]);
 
-  const { mutate: updateLeagueTeamMutation } = useUpdateLeagueTeam();
+  const { mutate: updateLeagueTeam, isPending } = useUpdateLeagueTeam();
 
   const onSubmit = async (data: TeamFormSchema) => {
+    if (isPending) return;
+
     let imageUrl: string;
     if (data.logo instanceof File) imageUrl = await uploadImage(data.logo);
     else imageUrl = data.logo;
 
-    updateLeagueTeamMutation(
+    updateLeagueTeam(
       {
         leagueId,
         teamId,

--- a/apps/manager/app/league/_components/LeagueCard/index.tsx
+++ b/apps/manager/app/league/_components/LeagueCard/index.tsx
@@ -47,7 +47,7 @@ const LeagueCard = () => {
                   <strong>참여</strong>&nbsp;{league.sizeOfLeagueTeams}개 팀
                 </p>
                 <p className={styles.leagueDescription}>
-                  <strong>라운드</strong>&nbsp;{league.maxRound}
+                  <strong>라운드</strong>&nbsp;{league.maxRound}강
                 </p>
                 <p className={styles.leagueDescription}>
                   <strong>기간</strong>&nbsp;

--- a/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
+++ b/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
@@ -126,7 +126,11 @@ export const LeagueForm = ({
                 <FormControl>
                   <SelectTrigger type="button">
                     <SelectValue>
-                      {Number(field.value) > 2 ? `${field.value}강` : `결승`}
+                      {field.value === '-'
+                        ? '-'
+                        : Number(field.value) > 2
+                          ? `${field.value}강`
+                          : `결승`}
                     </SelectValue>
                   </SelectTrigger>
                 </FormControl>

--- a/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
+++ b/apps/manager/app/league/_components/LeagueForm/LeagueForm.tsx
@@ -125,7 +125,9 @@ export const LeagueForm = ({
                 <FormLabel>진행 방식</FormLabel>
                 <FormControl>
                   <SelectTrigger type="button">
-                    <SelectValue>{field.value}강</SelectValue>
+                    <SelectValue>
+                      {Number(field.value) > 2 ? `${field.value}강` : `결승`}
+                    </SelectValue>
                   </SelectTrigger>
                 </FormControl>
                 <SelectContent>

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -24,11 +24,13 @@ export default function Page() {
     defaultValues: leagueDefaultValues,
   });
 
-  const { mutate: createLeagueMutation } = useCreateLeague();
+  const { mutate: createLeague, isPending } = useCreateLeague();
 
   const onSubmit = (data: LeagueFormSchema) => {
+    if (isPending) return;
+
     const { leagueName, round, startDate, endDate } = data;
-    createLeagueMutation(
+    createLeague(
       {
         name: leagueName,
         maxRound: Number(round),

--- a/apps/manager/app/league/register/page.tsx
+++ b/apps/manager/app/league/register/page.tsx
@@ -33,7 +33,7 @@ export default function Page() {
         name: leagueName,
         maxRound: Number(round),
         startAt: formatTime(startDate, 'YYYY-MM-DDTHH:mm:ss'),
-        endAt: formatTime(endDate, 'YYYY-MM-DDTHH:mm:ss'),
+        endAt: formatTime(endDate, 'YYYY-MM-DDT23:59:59'),
       },
       {
         onSuccess: () => {

--- a/apps/manager/constants/games.ts
+++ b/apps/manager/constants/games.ts
@@ -31,18 +31,16 @@ export const getStateByQuarter = (quarter: QUARTER_KEY): StateType => {
 export const getProgressTypeByQuarter = (
   quarter: QUARTER_KEY,
 ): ProgressType => {
-  switch (quarter) {
-    case '전반전':
-      return 'QUARTER_START';
-    case '후반전':
-      return 'QUARTER_START';
-    case '승부차기':
-      return 'QUARTER_START';
-    case '경기 종료':
-      return 'GAME_END';
-    default:
-      return 'GAME_END';
-  }
+  const progressMap: Record<QUARTER_KEY, ProgressType> = {
+    전반전: 'QUARTER_START',
+    후반전: 'QUARTER_START',
+    연장전: 'QUARTER_START',
+    승부차기: 'QUARTER_START',
+    '경기 종료': 'GAME_END',
+    경기전: 'GAME_END',
+  };
+
+  return progressMap[quarter] || 'GAME_END';
 };
 
 export const getProgressSemantics = (progressType: ProgressType): string => {

--- a/packages/api/src/mutations/useCreateLeague.ts
+++ b/packages/api/src/mutations/useCreateLeague.ts
@@ -16,7 +16,11 @@ const useCreateLeague = () => {
   return useMutation({
     mutationFn: postCreateLeague,
     onSuccess: async () => {
-      await queryClient.invalidateQueries(queryKeys.leagues());
+      await Promise.all([
+        queryClient.invalidateQueries(queryKeys.leagues()),
+        queryClient.invalidateQueries(queryKeys.leaguesOnManager()),
+        queryClient.invalidateQueries(queryKeys.leaguesManageOnManager()),
+      ]);
     },
   });
 };

--- a/packages/api/src/mutations/useDeleteLeague.ts
+++ b/packages/api/src/mutations/useDeleteLeague.ts
@@ -17,8 +17,12 @@ const useDeleteLeague = () => {
   return useMutation({
     mutationFn: deleteLeague,
     onSuccess: async (_, variables) => {
-      await queryClient.invalidateQueries(queryKeys.leagues());
-      await queryClient.invalidateQueries(queryKeys.league(variables.leagueId));
+      await Promise.all([
+        queryClient.invalidateQueries(queryKeys.leagues()),
+        queryClient.invalidateQueries(queryKeys.leaguesOnManager()),
+        queryClient.invalidateQueries(queryKeys.leaguesManageOnManager()),
+        queryClient.invalidateQueries(queryKeys.league(variables.leagueId)),
+      ]);
     },
   });
 };

--- a/packages/api/src/mutations/useUpdateLeague.ts
+++ b/packages/api/src/mutations/useUpdateLeague.ts
@@ -19,8 +19,12 @@ const useUpdateLeague = () => {
   return useMutation({
     mutationFn: putUpdateLeague,
     onSuccess: async (_, variables) => {
-      await queryClient.invalidateQueries(queryKeys.leagues());
-      await queryClient.invalidateQueries(queryKeys.league(variables.leagueId));
+      await Promise.all([
+        queryClient.invalidateQueries(queryKeys.leagues()),
+        queryClient.invalidateQueries(queryKeys.leaguesOnManager()),
+        queryClient.invalidateQueries(queryKeys.leaguesManageOnManager()),
+        queryClient.invalidateQueries(queryKeys.league(variables.leagueId)),
+      ]);
     },
   });
 };


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #343 

## ✅ 작업 내용

- 매니저 앱에서 대회 및 게임 생성, 수정 시 문제가 발생하여 아래와 같은 이슈를 해결했습니다. 
  - 게임 시작 시 state = "PLAYING " 값이 넘어가는 문제 해결
  - 타인라인 - 연장전 변경 시 경기가 종료되는 문제 해결
  - 대회 생성 시 종료일 시간을 "23:59"로 변경
  - 경기 생성, 경기 수정, 응원톡 차단, 응원톡 복구, 대회 생성, 대회 수정, 팀 생성, 팀 생성, 팀 수정 페이지에 요청 isPending 핸들링
  - 팀 생성 페이지에 선수 등록을 하지 않았을 경우, Toast 출력
  - 경기 삭제 시 경기 목록으로 이동
  - 대회 생성 시 생성 대회 새로고침 되도록 변경