### PR TITLE
refactor: AlertDialog 공통 컴포넌트로 변경

### DIFF
--- a/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/page.tsx
@@ -1,12 +1,11 @@
 'use client';
 import { useDeleteGame, useGame, useUpdateGame } from '@hcc/api';
-import { useToast } from '@hcc/ui';
+import { AlertDialog, useToast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
-import AlertDialog from '@/components/AlertDialog';
 import Layout from '@/components/Layout';
 import { getStateByQuarter, QUARTER_KEY } from '@/constants/games';
 import { formatTime } from '@/utils/time';

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/RecordDeleteMenu/index.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/RecordDeleteMenu/index.tsx
@@ -1,7 +1,6 @@
 import { TimelineRecordType, useDeleteTimeline } from '@hcc/api';
+import { AlertDialog } from '@hcc/ui';
 import Image from 'next/image';
-
-import AlertDialog from '@/components/AlertDialog';
 
 import * as styles from './styles.css';
 import { getRecordSubtitle, getRecordTitle } from '../../_utils/record';

--- a/apps/manager/app/league/[leagueId]/cheer-talk/blocked/page.tsx
+++ b/apps/manager/app/league/[leagueId]/cheer-talk/blocked/page.tsx
@@ -1,9 +1,8 @@
 'use client';
 import { useLeagueCheerTalkBlocked, useUpdateCheerTalkUnblock } from '@hcc/api';
-import { Button, useToast } from '@hcc/ui';
+import { AlertDialog, Button, useToast } from '@hcc/ui';
 import { Suspense } from 'react';
 
-import AlertDialog from '@/components/AlertDialog';
 import Layout from '@/components/Layout';
 
 import CheerTalkList from '../_components/CheerTalkList';

--- a/apps/manager/app/league/[leagueId]/manage/page.tsx
+++ b/apps/manager/app/league/[leagueId]/manage/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { useDeleteLeague, useLeague, useUpdateLeague } from '@hcc/api';
-import { toast } from '@hcc/ui';
+import { AlertDialog, toast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
@@ -12,7 +12,6 @@ import {
   leagueFormSchema,
   LeagueFormSchema,
 } from '@/app/league/_components/LeagueForm';
-import AlertDialog from '@/components/AlertDialog';
 import Layout from '@/components/Layout';
 import Tip from '@/components/Tip';
 import { formatTime } from '@/utils/time';

--- a/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
+++ b/apps/manager/app/league/[leagueId]/team/[teamId]/page.tsx
@@ -6,13 +6,12 @@ import {
   useLeagueTeam,
   useUpdateLeagueTeam,
 } from '@hcc/api';
-import { useToast } from '@hcc/ui';
+import { AlertDialog, useToast } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
 import { useRouter } from 'next/navigation';
 import { useEffect } from 'react';
 import { useForm } from 'react-hook-form';
 
-import AlertDialog from '@/components/AlertDialog';
 import Layout from '@/components/Layout';
 import { useImageUpload } from '@/hooks/useImageUpload';
 

--- a/packages/ui/src/alert-dialog/alert-dialog.tsx
+++ b/packages/ui/src/alert-dialog/alert-dialog.tsx
@@ -1,4 +1,4 @@
-'use client';
+import { isValidElement, ReactNode } from 'react';
 
 import {
   Button,
@@ -11,10 +11,9 @@ import {
   DialogOverlay,
   DialogTitle,
   DialogTrigger,
-} from '@hcc/ui';
-import { isValidElement, ReactNode } from 'react';
+} from '..';
 
-type AlertDialogProps = {
+export type AlertDialogProps = {
   title: string;
   description: ReactNode;
   primaryActionLabel: string;
@@ -24,7 +23,7 @@ type AlertDialogProps = {
   children: ReactNode;
 };
 
-const AlertDialog = ({
+export const AlertDialog = ({
   title,
   description,
   primaryActionLabel,
@@ -80,5 +79,3 @@ const AlertDialog = ({
     </Dialog>
   );
 };
-
-export default AlertDialog;

--- a/packages/ui/src/alert-dialog/index.tsx
+++ b/packages/ui/src/alert-dialog/index.tsx
@@ -1,0 +1,1 @@
+export * from './alert-dialog';

--- a/packages/ui/src/index.ts
+++ b/packages/ui/src/index.ts
@@ -18,3 +18,4 @@ export * from './spinner';
 export * from './toast';
 export * from './tag';
 export * from './badge';
+export * from './alert-dialog';


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #345 

## ✅ 작업 내용

- manager 및 spectator 앱에서 같은 `AlertDialog` 컴포넌트를 사용하게 되어, 이를 공통 컴포넌트로 이동했습니다.