### PR TITLE
fix: 타임라인 선수 교체 시 Query 캐시 제거

### DIFF
--- a/packages/api/src/mutations/useCreateReplacementTimeline.ts
+++ b/packages/api/src/mutations/useCreateReplacementTimeline.ts
@@ -26,6 +26,10 @@ const useCreateReplacementTimeline = () => {
         queryClient.invalidateQueries(queryKeys.game(variables.gameId)),
         queryClient.invalidateQueries(queryKeys.leaguesOnManager()),
         queryClient.invalidateQueries(queryKeys.leaguesManageOnManager()),
+        queryClient.invalidateQueries(queryKeys.lineup(variables.gameId)),
+        queryClient.invalidateQueries(
+          queryKeys.lineupPlaying(variables.gameId),
+        ),
       ]);
     },
   });


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #347

## ✅ 작업 내용

- 매니저 타임라인 선수 교체 시, 라인업 및 선발 라인업 선수 캐시를 제거하도록 했습니다.