### PR TITLE
fix: 타임라인 및 선수 선택 개선

### DIFF
--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ReplacementForm.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ReplacementForm.tsx
@@ -21,7 +21,7 @@ import {
   useToast,
 } from '@hcc/ui';
 import { zodResolver } from '@hookform/resolvers/zod';
-import { useEffect, useMemo } from 'react';
+import { useMemo } from 'react';
 import { useForm } from 'react-hook-form';
 
 import TimeInput from '@/components/TimeInput';
@@ -99,11 +99,6 @@ const ReplacementForm = ({
     );
   }, [lineupPlayers, gameTeamId]);
 
-  useEffect(() => {
-    methods.setValue('originLineupPlayerId', '');
-    methods.setValue('replacementLineupPlayerId', '');
-  }, [gameTeamId, methods]);
-
   if (!quarter)
     return (
       <p className={styles.emptyQuarterMessage}>
@@ -148,7 +143,14 @@ const ReplacementForm = ({
             name="gameTeamId"
             render={({ field }) => (
               <FormItem>
-                <Select onValueChange={field.onChange} value={field.value}>
+                <Select
+                  onValueChange={e => {
+                    field.onChange(e);
+                    methods.setValue('originLineupPlayerId', '');
+                    methods.setValue('replacementLineupPlayerId', '');
+                  }}
+                  value={field.value}
+                >
                   <FormLabel>팀 명</FormLabel>
                   <FormControl>
                     <SelectTrigger type="button">
@@ -181,59 +183,77 @@ const ReplacementForm = ({
           <FormField
             control={methods.control}
             name="replacementLineupPlayerId"
-            render={({ field }) => (
-              <FormItem>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormLabel>교체 투입 선수</FormLabel>
-                  <FormControl>
-                    <SelectTrigger type="button">
-                      <SelectValue>
-                        {players.find(
-                          player => player.id.toString() === field.value,
-                        )?.playerName ?? '선수 선택'}
-                      </SelectValue>
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {players.map(player => (
-                      <SelectItem key={player.id} value={player.id.toString()}>
-                        {player.playerName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
+            render={({ field }) => {
+              const selectedPlayer = players.find(
+                player => player.id.toString() === field.value,
+              );
+
+              return (
+                <FormItem>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormLabel>교체 투입 선수</FormLabel>
+                    <FormControl>
+                      <SelectTrigger type="button">
+                        <SelectValue>
+                          {selectedPlayer
+                            ? `${selectedPlayer?.playerName}(${selectedPlayer?.number})`
+                            : '선수 선택'}
+                        </SelectValue>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {players.map(player => (
+                        <SelectItem
+                          key={player.id}
+                          value={player.id.toString()}
+                        >
+                          {player.playerName}({player.number})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
           />
 
           <FormField
             control={methods.control}
             name="originLineupPlayerId"
-            render={({ field }) => (
-              <FormItem>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormLabel>교체 아웃 선수</FormLabel>
-                  <FormControl>
-                    <SelectTrigger type="button">
-                      <SelectValue>
-                        {playingPlayers.find(
-                          player => player.id.toString() === field.value,
-                        )?.playerName ?? '선수 선택'}
-                      </SelectValue>
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {playingPlayers.map(player => (
-                      <SelectItem key={player.id} value={player.id.toString()}>
-                        {player.playerName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
+            render={({ field }) => {
+              const selectedPlayer = playingPlayers.find(
+                player => player.id.toString() === field.value,
+              );
+
+              return (
+                <FormItem>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormLabel>교체 아웃 선수</FormLabel>
+                    <FormControl>
+                      <SelectTrigger type="button">
+                        <SelectValue>
+                          {selectedPlayer
+                            ? `${selectedPlayer?.playerName}(${selectedPlayer?.number})`
+                            : '선수 선택'}
+                        </SelectValue>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {playingPlayers.map(player => (
+                        <SelectItem
+                          key={player.id}
+                          value={player.id.toString()}
+                        >
+                          {player.playerName}({player.number})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
           />
 
           <FormField

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ScoreForm.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Form/ScoreForm.tsx
@@ -166,36 +166,44 @@ const ScoreForm = ({ gameId, onClose, quarter }: ScoreFormProps) => {
             )}
           />
         </section>
-
         <h4 className={styles.sectionTitle}>득점 상세 정보</h4>
         <section className={styles.section}>
           <FormField
             control={methods.control}
             name="scoreLineupPlayerId"
-            render={({ field }) => (
-              <FormItem>
-                <Select onValueChange={field.onChange} value={field.value}>
-                  <FormLabel>선수</FormLabel>
-                  <FormControl>
-                    <SelectTrigger type="button">
-                      <SelectValue>
-                        {players.find(
-                          player => player.id.toString() === field.value,
-                        )?.playerName ?? '선수 선택'}
-                      </SelectValue>
-                    </SelectTrigger>
-                  </FormControl>
-                  <SelectContent>
-                    {players.map(player => (
-                      <SelectItem key={player.id} value={player.id.toString()}>
-                        {player.playerName}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-                <FormMessage />
-              </FormItem>
-            )}
+            render={({ field }) => {
+              const selectedPlayer = players.find(
+                player => player.id.toString() === field.value,
+              );
+
+              return (
+                <FormItem>
+                  <Select onValueChange={field.onChange} value={field.value}>
+                    <FormLabel>선수</FormLabel>
+                    <FormControl>
+                      <SelectTrigger type="button">
+                        <SelectValue>
+                          {selectedPlayer
+                            ? `${selectedPlayer?.playerName}(${selectedPlayer?.number})`
+                            : '선수 선택'}
+                        </SelectValue>
+                      </SelectTrigger>
+                    </FormControl>
+                    <SelectContent>
+                      {players.map(player => (
+                        <SelectItem
+                          key={player.id}
+                          value={player.id.toString()}
+                        >
+                          {player.playerName}({player.number})
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                  <FormMessage />
+                </FormItem>
+              );
+            }}
           />
 
           <FormField
@@ -212,7 +220,6 @@ const ScoreForm = ({ gameId, onClose, quarter }: ScoreFormProps) => {
             )}
           />
         </section>
-
         <Button
           disabled={isPending}
           type="submit"

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Record/EventRecord.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Record/EventRecord.tsx
@@ -17,7 +17,7 @@ const EventRecord = ({ record, homeTeamId }: EventRecordProps) => {
   const isAway = record.gameTeamId !== homeTeamId;
 
   return (
-    <div
+    <li
       className={clsx(styles.eventRecordContainer, {
         [styles.eventRecordAwayContainer]: isAway,
       })}
@@ -33,7 +33,7 @@ const EventRecord = ({ record, homeTeamId }: EventRecordProps) => {
           {getRecordSubtitle(record)}
         </p>
       </div>
-    </div>
+    </li>
   );
 };
 

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Record/TextRecord.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/Record/TextRecord.tsx
@@ -3,7 +3,7 @@ import { ComponentProps, ReactNode } from 'react';
 
 import * as styles from './styles.css';
 
-type TextRecordProps = ComponentProps<'div'> & {
+type TextRecordProps = ComponentProps<'li'> & {
   showDividerLine?: boolean;
   className?: string;
   children: ReactNode;
@@ -16,7 +16,7 @@ const TextRecord = ({
   ...props
 }: TextRecordProps) => {
   return (
-    <div
+    <li
       className={clsx(styles.textRecordContainer, className, {
         [styles.textRecordCenter]: !showDividerLine,
       })}
@@ -25,7 +25,7 @@ const TextRecord = ({
       {showDividerLine && <div className={styles.textRecordDivider} />}
       <p className={styles.textRecordText}>{children}</p>
       {showDividerLine && <div className={styles.textRecordDivider} />}
-    </div>
+    </li>
   );
 };
 

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/RecordDeleteMenu/index.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_components/RecordDeleteMenu/index.tsx
@@ -8,7 +8,7 @@ import { getRecordSubtitle, getRecordTitle } from '../../_utils/record';
 
 type RecordDeleteMenuProps = {
   gameId: string;
-  record: TimelineRecordType | undefined;
+  record: TimelineRecordType | null;
 };
 
 const RecordDeleteMenu = ({ gameId, record }: RecordDeleteMenuProps) => {

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/_utils/record.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/_utils/record.tsx
@@ -23,7 +23,7 @@ export const getRecordTitle = (record: TimelineRecordType) => {
   if (record.type === 'REPLACEMENT') {
     return `${record.replacementRecord.replacedPlayerName} IN`;
   }
-  return record.playerName;
+  return `${record.playerName}`;
 };
 
 export const getRecordSubtitle = (record: TimelineRecordType) => {

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/page.tsx
@@ -1,10 +1,5 @@
 'use client';
-import {
-  TimelineRecordType,
-  TimelineType,
-  useGame,
-  useTimeline,
-} from '@hcc/api';
+import { TimelineRecordType, useGame, useTimeline } from '@hcc/api';
 import { Fragment } from 'react';
 
 import Layout from '@/components/Layout';
@@ -30,14 +25,12 @@ export default function Page({ params }: PageProps) {
 
   const homeTeamId: number = game.gameTeams[0].gameTeamId;
 
-  const sortedTimelines: TimelineType[] = timelines.map(timeline => ({
-    ...timeline,
-    records: timeline.records.sort((a, b) => b.recordId - a.recordId),
-  }));
-  const lastRecord: TimelineRecordType | undefined =
-    sortedTimelines?.[0]?.records?.[0] ?? undefined;
+  const lastRecord: TimelineRecordType | null =
+    timelines
+      .flatMap(item => item.records)
+      .sort((a, b) => b.recordId - a.recordId)[0] ?? null;
 
-  const currentQuarter = sortedTimelines[0]?.gameQuarter ?? undefined;
+  const currentQuarter = timelines[0]?.gameQuarter ?? null;
 
   return (
     <Layout
@@ -57,7 +50,7 @@ export default function Page({ params }: PageProps) {
             </TextRecord>
           </Fragment>
         )}
-        {sortedTimelines.map(timeline => {
+        {timelines.map(timeline => {
           return (
             <Fragment key={timeline.gameQuarter}>
               {timeline.records.map(record => {

--- a/apps/manager/app/league/[leagueId]/[gameId]/timeline/page.tsx
+++ b/apps/manager/app/league/[leagueId]/[gameId]/timeline/page.tsx
@@ -46,7 +46,7 @@ export default function Page({ params }: PageProps) {
     >
       <GameScoreBanner game={game} />
 
-      <div className={styles.timeline}>
+      <ul className={styles.timeline}>
         {game.state === 'FINISHED' && (
           <Fragment>
             <TextRecord>경기가 종료되었습니다.</TextRecord>
@@ -62,6 +62,7 @@ export default function Page({ params }: PageProps) {
             <Fragment key={timeline.gameQuarter}>
               {timeline.records.map(record => {
                 if (record.type === 'GAME_PROGRESS') {
+                  if (timeline.gameQuarter === '경기 종료') return null;
                   return (
                     <TextRecord key={record.recordId} showDividerLine={true}>
                       {timeline.gameQuarter}이(가)&nbsp;
@@ -83,7 +84,7 @@ export default function Page({ params }: PageProps) {
             </Fragment>
           );
         })}
-      </div>
+      </ul>
 
       <BottomMenu gameId={gameId} quarter={currentQuarter} />
     </Layout>

--- a/apps/spectator/app/game/[id]/_components/Lineup/PlayingLineup.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/PlayingLineup.tsx
@@ -1,0 +1,53 @@
+import { useGameLineupPlaying } from '@hcc/api';
+import { clsx } from 'clsx';
+
+import PlayerList from './PlayerList';
+import * as styles from './styles.css';
+
+type StartingProps = {
+  gameId: string;
+};
+
+export const PlayingLineup = ({ gameId }: StartingProps) => {
+  const { data } = useGameLineupPlaying(gameId);
+
+  if (!data) return null;
+
+  const [homeTeam, awayTeam] = data;
+
+  return (
+    <div className={clsx(styles.container, styles.starterContainer)}>
+      <div className={styles.teamContainer}>
+        <div className={styles.team.left}>
+          {/*<Image*/}
+          {/*  src={homeTeam.logoImageUrl}*/}
+          {/*  alt={`${homeTeam.teamName} logo image`}*/}
+          {/*  width={28}*/}
+          {/*  height={28}*/}
+          {/*  loading="lazy"*/}
+          {/*/>*/}
+          <span className={styles.teamName.left}>{homeTeam.teamName}</span>
+        </div>
+
+        <PlayerList players={homeTeam.gameTeamPlayers} direction="left" />
+      </div>
+
+      <div className={styles.divider} />
+
+      <div className={styles.teamContainer}>
+        <div className={styles.team.right}>
+          <span className={styles.teamName.right}>{awayTeam.teamName}</span>
+          {/*<Image*/}
+          {/*  src={awayTeam.logoImageUrl}*/}
+          {/*  alt={`${awayTeam.teamName} logo image`}*/}
+          {/*  width={28}*/}
+          {/*  height={28}*/}
+          {/*  loading="lazy"*/}
+          {/*/>*/}
+        </div>
+
+        <PlayerList players={awayTeam.gameTeamPlayers} direction="right" />
+      </div>
+    </div>
+  );
+};

--- a/apps/spectator/app/game/[id]/_components/Timeline/Timeline.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Timeline/Timeline.css.ts
@@ -35,6 +35,10 @@ export const textRecordText = style({
   textAlign: 'center',
 });
 
+export const summaryRecord = style({
+  paddingTop: 0,
+});
+
 // Event Record
 export const eventRecordContainer = style({
   position: 'relative',

--- a/apps/spectator/app/game/[id]/_components/Timeline/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/Timeline/index.tsx
@@ -30,12 +30,23 @@ export default function Timeline({ gameId }: TimelineProps) {
   const homeTeamId: number = game?.gameTeams[0].gameTeamId;
 
   return (
-    <Fragment>
+    <ul className={styles.root}>
+      {game.state === 'FINISHED' && (
+        <Fragment>
+          <TextRecord>경기가 종료되었습니다.</TextRecord>
+          <TextRecord className={styles.summaryRecord}>
+            경기 결과 - {game.gameTeams[0].score}:{game.gameTeams[1].score}
+            {game.isPkTaken &&
+              ` (${game.gameTeams[0].pkScore}:${game.gameTeams[1].pkScore})`}
+          </TextRecord>
+        </Fragment>
+      )}
       {timelines.map(timeline => {
         return (
-          <ul key={timeline.gameQuarter} className={styles.root}>
+          <Fragment key={timeline.gameQuarter}>
             {timeline.records.map(record => {
-              if (record.progressRecord?.gameProgressType)
+              if (record.progressRecord?.gameProgressType) {
+                if (timeline.gameQuarter === '경기 종료') return null;
                 return (
                   <TextRecord key={record.recordId} showDividerLine={true}>
                     {timeline.gameQuarter}이(가)&nbsp;
@@ -45,6 +56,7 @@ export default function Timeline({ gameId }: TimelineProps) {
                     되었습니다.
                   </TextRecord>
                 );
+              }
 
               return (
                 <EventRecord
@@ -54,9 +66,9 @@ export default function Timeline({ gameId }: TimelineProps) {
                 />
               );
             })}
-          </ul>
+          </Fragment>
         );
       })}
-    </Fragment>
+    </ul>
   );
 }


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- #353 

## ✅ 작업 내용

- 유로컵 진행 중 확인된 일부 오류를 개선했습니다.
  -  타임라인 삭제 시 올바르지 않은 ID가 선택되는 문제 해결했습니다.
  -  선수 변경 및 득점 추가 시 선수 번호를 같이 보여주도록 구현했습니다.
  -  게임 종료 텍스트를 수정하고, 스코어가 같이 보이도록 구현했습니다.
<table>
<tr>
<td>
<img width="250" alt="image" src="https://github.com/user-attachments/assets/b2497c2d-17e8-4c72-bb10-eaf780384cfe">
</td>
<td>
<img width="250" alt="image" src="https://github.com/user-attachments/assets/7ee16372-72e4-4110-8e04-cf8e0d6001af">
</td>
<td>
<img width="250" alt="image" src="https://github.com/user-attachments/assets/5256c098-0a87-4c62-8210-084977cf9a21">
</td>
</tr>
</table>


## ♾️ 기타

- `/lineup/playing`와 `/lineup`에서 반환하는 선수 리스트가 잘 이해가 안 돼서 승희에게 물어본 상태입니다. (현재 선수 교체가 제대로 동작이 안 돼요.) 이거 답변에 따라 백엔드 혹은 프론트 일부 코드 수정하도록 하겠습니다.