### PR TITLE
feat: qa 반영

### DIFF
--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -1,4 +1,3 @@
-import { theme } from '@hcc/styles';
 import Image from 'next/image';
 
 import { GameListType, GameState } from '@/types/game';
@@ -10,8 +9,6 @@ type GameInfoProps = {
   state: GameState;
 };
 
-const IMAGE_SIZE = 26;
-
 export default function GameInfo({ gameTeams, state }: GameInfoProps) {
   // todo: fisished 상태일 때 경기 승패를 score 색상으로 표시
   const [firstTeam, secondTeam] = gameTeams;
@@ -20,17 +17,15 @@ export default function GameInfo({ gameTeams, state }: GameInfoProps) {
     <div className={styles.infoContainer}>
       <div className={styles.gameInfoRow.root}>
         <div className={styles.gameInfoRow.team}>
-          <Image
-            src={firstTeam.logoImageUrl}
-            alt={`${firstTeam.gameTeamName} logo`}
-            width={IMAGE_SIZE}
-            height={IMAGE_SIZE}
-            loading="lazy"
-            style={{
-              border: `1px solid ${theme.colors.gray50}`,
-              borderRadius: '50%',
-            }}
-          />
+          <div className={styles.logoContainer}>
+            <Image
+              src={firstTeam.logoImageUrl}
+              alt={`${firstTeam.gameTeamName} logo`}
+              loading="lazy"
+              fill
+              className={styles.logoImg}
+            />
+          </div>
           <span className={styles.gameInfoRow.teamName}>
             {firstTeam.gameTeamName}
           </span>
@@ -39,17 +34,15 @@ export default function GameInfo({ gameTeams, state }: GameInfoProps) {
       </div>
       <div className={styles.gameInfoRow.root}>
         <div className={styles.gameInfoRow.team}>
-          <Image
-            src={secondTeam.logoImageUrl}
-            alt={`${secondTeam.gameTeamName} logo`}
-            width={IMAGE_SIZE}
-            height={IMAGE_SIZE}
-            loading="lazy"
-            style={{
-              border: `1px solid ${theme.colors.gray50}`,
-              borderRadius: '50%',
-            }}
-          />
+          <div className={styles.logoContainer}>
+            <Image
+              src={secondTeam.logoImageUrl}
+              alt={`${secondTeam.gameTeamName} logo`}
+              loading="lazy"
+              fill
+              className={styles.logoImg}
+            />
+          </div>
           <span className={styles.gameInfoRow.teamName}>
             {secondTeam.gameTeamName}
           </span>

--- a/apps/spectator/app/_components/GameList/Info.tsx
+++ b/apps/spectator/app/_components/GameList/Info.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@hcc/styles';
 import Image from 'next/image';
 
 import { GameListType, GameState } from '@/types/game';
@@ -25,6 +26,10 @@ export default function GameInfo({ gameTeams, state }: GameInfoProps) {
             width={IMAGE_SIZE}
             height={IMAGE_SIZE}
             loading="lazy"
+            style={{
+              border: `1px solid ${theme.colors.gray50}`,
+              borderRadius: '50%',
+            }}
           />
           <span className={styles.gameInfoRow.teamName}>
             {firstTeam.gameTeamName}
@@ -40,6 +45,10 @@ export default function GameInfo({ gameTeams, state }: GameInfoProps) {
             width={IMAGE_SIZE}
             height={IMAGE_SIZE}
             loading="lazy"
+            style={{
+              border: `1px solid ${theme.colors.gray50}`,
+              borderRadius: '50%',
+            }}
           />
           <span className={styles.gameInfoRow.teamName}>
             {secondTeam.gameTeamName}

--- a/apps/spectator/app/_components/GameList/styles.css.ts
+++ b/apps/spectator/app/_components/GameList/styles.css.ts
@@ -176,3 +176,15 @@ export const errorFallback = styleVariants({
     color: theme.colors.gray[5],
   },
 });
+
+export const logoContainer = style({
+  width: rem(26),
+  height: rem(26),
+  position: 'relative',
+});
+
+export const logoImg = style({
+  border: `1px solid ${theme.colors.gray50}`,
+  borderRadius: '50%',
+  objectFit: 'cover',
+});

--- a/apps/spectator/app/_components/GameList/styles.css.ts
+++ b/apps/spectator/app/_components/GameList/styles.css.ts
@@ -55,8 +55,20 @@ export const state = styleVariants({
       backgroundColor: theme.colors.red600,
     },
   ],
-  SCHEDULED: [baseState],
-  FINISHED: [baseState],
+  SCHEDULED: [
+    baseState,
+    {
+      color: theme.colors.blue600,
+      backgroundColor: theme.colors.blue200,
+    },
+  ],
+  FINISHED: [
+    baseState,
+    {
+      color: theme.colors.white,
+      backgroundColor: theme.colors.gray300,
+    },
+  ],
 });
 
 export const timestamp = style({

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/Item/Item.css.ts
@@ -38,6 +38,8 @@ export const item = styleVariants({
   teamLogo: {
     userSelect: 'none',
     alignSelf: 'center',
+    border: `1px solid ${theme.colors.gray50}`,
+    borderRadius: '50%',
   },
   content: {
     padding: `${theme.spaces.xs} ${theme.spaces.sm}`,

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/List/List.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/List/List.css.ts
@@ -17,6 +17,14 @@ export const list = styleVariants({
   },
 });
 
+export const emptyMsg = style({
+  display: 'flex',
+  flex: 1,
+  fontSize: theme.textVariants.default.fontSize,
+  alignItems: 'center',
+  justifyContent: 'center',
+});
+
 export const scrollToBottomButton = style({
   position: 'absolute',
   display: 'flex',

--- a/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerTalk/List/index.tsx
@@ -94,43 +94,50 @@ export default function CheerTalkList({
   }, [checkScrollHeight]);
 
   return (
-    <div className={styles.list.container}>
-      <ul ref={scrollRef} className={styles.list.content}>
-        {hasNextPage && <Spinner />}
-        <li ref={ref} />
-        {/* HTTP */}
-        {cheerTalkList.map(talk => (
-          <CheerTalkItemMemo
-            key={`cheer-${talk.cheerTalkId}`}
-            hasMenu
-            {...talk}
-          />
-        ))}
-
-        {/* Socket */}
-        {socketTalkList.map(talk => (
-          <CheerTalkItemMemo
-            key={`socket-${talk.cheerTalkId}`}
-            hasMenu
-            {...talk}
-          />
-        ))}
-        <li ref={bottomRef} />
-      </ul>
-      <CheerTalkForm
-        gameTeams={gameDetail.gameTeams}
-        saveCheerTalkMutate={mutate}
-        scrollToBottom={run}
-      />
-      {showScrollToBottomButton && (
-        <button
-          className={styles.scrollToBottomButton}
-          onClick={run}
-          type="button"
-        >
-          <Icon source={ArrowDownIcon} size={16} color="black" />
-        </button>
+    <>
+      {cheerTalkList.length === 0 && socketTalkList.length === 0 && (
+        <div className={styles.emptyMsg}>
+          지금 우리 팀에게 첫 응원톡을 남겨주세요! 💪
+        </div>
       )}
-    </div>
+      <div className={styles.list.container}>
+        <ul ref={scrollRef} className={styles.list.content}>
+          {hasNextPage && <Spinner />}
+          <li ref={ref} />
+          {/* HTTP */}
+          {cheerTalkList.map(talk => (
+            <CheerTalkItemMemo
+              key={`cheer-${talk.cheerTalkId}`}
+              hasMenu
+              {...talk}
+            />
+          ))}
+
+          {/* Socket */}
+          {socketTalkList.map(talk => (
+            <CheerTalkItemMemo
+              key={`socket-${talk.cheerTalkId}`}
+              hasMenu
+              {...talk}
+            />
+          ))}
+          <li ref={bottomRef} />
+        </ul>
+        <CheerTalkForm
+          gameTeams={gameDetail.gameTeams}
+          saveCheerTalkMutate={mutate}
+          scrollToBottom={run}
+        />
+        {showScrollToBottomButton && (
+          <button
+            className={styles.scrollToBottomButton}
+            onClick={run}
+            type="button"
+          >
+            <Icon source={ArrowDownIcon} size={16} color="black" />
+          </button>
+        )}
+      </div>
+    </>
   );
 }

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -1,6 +1,5 @@
 'use client';
 
-import { theme } from '@hcc/styles';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -74,17 +73,15 @@ export default function CheerTeamBox({
       })}
       onClick={handleCheerClick}
     >
-      <Image
-        width={36}
-        height={36}
-        src={logoImageUrl}
-        alt={`${gameTeamName} 로고`}
-        loading="lazy"
-        style={{
-          border: `1px solid ${theme.colors.gray50}`,
-          borderRadius: '50%',
-        }}
-      />
+      <div className={styles.logoContainer}>
+        <Image
+          src={logoImageUrl}
+          alt={`${gameTeamName} 로고`}
+          loading="lazy"
+          fill
+          className={styles.logoImg}
+        />
+      </div>
       <span className={styles.countNumber}>
         {count.toLocaleString('ko-KR')}
       </span>

--- a/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/TeamBox.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { theme } from '@hcc/styles';
 import { assignInlineVars } from '@vanilla-extract/dynamic';
 import Image from 'next/image';
 import { useState } from 'react';
@@ -79,6 +80,10 @@ export default function CheerTeamBox({
         src={logoImageUrl}
         alt={`${gameTeamName} 로고`}
         loading="lazy"
+        style={{
+          border: `1px solid ${theme.colors.gray50}`,
+          borderRadius: '50%',
+        }}
       />
       <span className={styles.countNumber}>
         {count.toLocaleString('ko-KR')}

--- a/apps/spectator/app/game/[id]/_components/CheerVS/styles.css.ts
+++ b/apps/spectator/app/game/[id]/_components/CheerVS/styles.css.ts
@@ -128,3 +128,15 @@ export const skeleton = styleVariants({
     },
   ],
 });
+
+export const logoContainer = style({
+  width: rem(36),
+  height: rem(36),
+  position: 'relative',
+});
+
+export const logoImg = style({
+  border: `1px solid ${theme.colors.gray50}`,
+  borderRadius: '50%',
+  objectFit: 'cover',
+});

--- a/apps/spectator/app/game/[id]/_components/Lineup/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/index.tsx
@@ -1,3 +1,4 @@
+import { theme } from '@hcc/styles';
 import { Accordion } from '@hcc/ui';
 import { clsx } from 'clsx';
 import Image from 'next/image';
@@ -27,6 +28,10 @@ export default function Lineup({ gameId }: LineupProps) {
               width={28}
               height={28}
               loading="lazy"
+              style={{
+                border: `1px solid ${theme.colors.gray50}`,
+                borderRadius: '50%',
+              }}
             />
             <span className={styles.teamName.left}>{homeTeam.teamName}</span>
           </div>
@@ -48,6 +53,10 @@ export default function Lineup({ gameId }: LineupProps) {
               width={28}
               height={28}
               loading="lazy"
+              style={{
+                border: `1px solid ${theme.colors.gray50}`,
+                borderRadius: '50%',
+              }}
             />
           </div>
 

--- a/apps/spectator/app/game/[id]/_components/Lineup/index.tsx
+++ b/apps/spectator/app/game/[id]/_components/Lineup/index.tsx
@@ -1,4 +1,3 @@
-import { theme } from '@hcc/styles';
 import { Accordion } from '@hcc/ui';
 import { clsx } from 'clsx';
 import Image from 'next/image';
@@ -22,17 +21,15 @@ export default function Lineup({ gameId }: LineupProps) {
       <div className={clsx(styles.container, styles.starterContainer)}>
         <div className={styles.teamContainer}>
           <div className={styles.team.left}>
-            <Image
-              src={homeTeam.logoImageUrl}
-              alt={`${homeTeam.teamName} logo image`}
-              width={28}
-              height={28}
-              loading="lazy"
-              style={{
-                border: `1px solid ${theme.colors.gray50}`,
-                borderRadius: '50%',
-              }}
-            />
+            <div className={styles.logoContainer}>
+              <Image
+                src={homeTeam.logoImageUrl}
+                alt={`${homeTeam.teamName} logo image`}
+                loading="lazy"
+                fill
+                className={styles.logoImg}
+              />
+            </div>
             <span className={styles.teamName.left}>{homeTeam.teamName}</span>
           </div>
 
@@ -47,17 +44,15 @@ export default function Lineup({ gameId }: LineupProps) {
         <div className={styles.teamContainer}>
           <div className={styles.team.right}>
             <span className={styles.teamName.right}>{awayTeam.teamName}</span>
-            <Image
-              src={awayTeam.logoImageUrl}
-              alt={`${awayTeam.teamName} logo image`}
-              width={28}
-              height={28}
-              loading="lazy"
-              style={{
-                border: `1px solid ${theme.colors.gray50}`,
-                borderRadius: '50%',
-              }}
-            />
+            <div className={styles.logoContainer}>
+              <Image
+                src={awayTeam.logoImageUrl}
+                alt={`${awayTeam.teamName} logo image`}
+                loading="lazy"
+                fill
+                className={styles.logoImg}
+              />
+            </div>
           </div>
 
           <PlayerList

--- a/apps/spectator/app/game/[id]/_components/Lineup/styles.css.ts
+++ b/apps/spectator/app/game/[id]/_components/Lineup/styles.css.ts
@@ -153,3 +153,15 @@ export const errorFallback = styleVariants({
     fontWeight: 500,
   },
 });
+
+export const logoContainer = style({
+  width: rem(28),
+  height: rem(28),
+  position: 'relative',
+});
+
+export const logoImg = style({
+  border: `1px solid ${theme.colors.gray50}`,
+  borderRadius: '50%',
+  objectFit: 'cover',
+});


### PR DESCRIPTION
## 🌍 이슈 번호 <!-- - #number -->

- 이슈 번호 #352 

## ✅ 작업 내용
- 경기 리스트, 응원 카운트, 라인업, 응원톡에 있는 로고 배경 제거했습니다.
- 예정, 종료 뱃지가 분간되도록 습니다.
- 아무런 응원톡이 작성되지 않은 경우 문구가 띄워지게 했습니다.
![image](https://github.com/user-attachments/assets/20c1ee2c-ac39-424e-b19a-d40f2ebf94ab)

## ♾️ 기타
- 경기가 없는 경우 메세지를 띄우는 작업은 빈 배열 데이터가 온 후 최종 데이터가 오고 있는 상태라 최종 데이터 분간이 안 돼서 학님이 이 부분은 봐주시기로 했습니다.
